### PR TITLE
CLEANUP: use C++-style casts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,15 @@ PLPATHS=-p library=prolog -p foreign="$(PACKSODIR)"
 
 all:	plugin
 
-rocksdb/INSTALL.md:
+.PHONY: FORCE all clean install check distclean realclean shared_object plugin
+
+rocksdb/INSTALL.md: FORCE
 	git submodule update --init rocksdb
 
 # Run the build for librocksdb in parallel, using # processors as
 # limit, if using GNU make
 JOBS=$(shell $(MAKE) --version 2>/dev/null | grep GNU >/dev/null && J=$$(nproc 2>/dev/null) && echo -j$$J)
-rocksdb/librocksdb.a: rocksdb/INSTALL.md
+rocksdb/librocksdb.a: rocksdb/INSTALL.md FORCE
 	$(ROCKSENV) $(MAKE) $(JOBS) -C rocksdb static_lib $(ROCKSCFLAGS)
 
 plugin:	$(LIBROCKSDB)

--- a/prolog/rocksdb.pl
+++ b/prolog/rocksdb.pl
@@ -139,6 +139,13 @@ See rocks_open/3 for details.
 %	  One of `read_write` (default) or `read_only`.  The latter
 %	  uses OpenForReadOnly() to open the database.
 
+%
+% @bug You must call rocks_close(Directory) to ensure clean shutdown
+%      Failure to call rdb_close/1 usually doesn't result in data
+%      loss because rocksdb can recover, depending on the setting
+%      of the `sync` option.
+% @see https://github.com/facebook/rocksdb/wiki/Known-Issues
+
 rocks_open(Dir, DB, Options0) :-
 	meta_options(is_meta, Options0, Options),
 	rocks_open_(Dir, DB, Options).

--- a/test/test_rocksdb.pl
+++ b/test/test_rocksdb.pl
@@ -82,6 +82,7 @@ test(batch, Pairs == [zus-noot]) :-
 	rocks_get(RocksDB, aap, Value),
 	rocks_batch(RocksDB,
 		    [ delete(aap),
+		      delete(xxxx), % doesn't exist, but that's OK
 		      put(zus, Value)
 		    ]),
 	findall(K-V, rocks_enum(RocksDB, K, V), Pairs),


### PR DESCRIPTION
IGNORE this comment -- I hadn't noticed the `test` directory.

The unit test is far from complete; I intend to add some more tests in future.
In particular, it's possible that my code changes broke rocks_merge/3, so a test should be added for that. Jan - if you have any code that exercises rocks_merge/3, please send it to me.