### PR TITLE
Changes for SWI-cpp2.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 #COFLAGS=-gdwarf-2 -g3
-CPPFLAGS=-std=c++17 -O2 $(CFLAGS) $(COFLAGS) $(LDSOFLAGS) -Irocksdb/include
+# The following flags are the same as rocksdb uses, except that rocksdb also has -Werror
+# TODO: add -Werror
+CPPFLAGS=-Wall -Wextra -Wsign-compare -Wshadow -Wunused-parameter -Woverloaded-virtual -Wnon-virtual-dtor -Wno-missing-field-initializers -Wno-invalid-offsetof  -std=c++17 -O2 $(CFLAGS) $(COFLAGS) $(LDSOFLAGS) -Irocksdb/include
 LIBROCKSDB=rocksdb/librocksdb.a
 ROCKSENV=ROCKSDB_DISABLE_JEMALLOC=1 ROCKSDB_DISABLE_TCMALLOC=1
 # DEBUG_LEVEL=0 implies -O2 without assertions and debug code
@@ -29,6 +31,12 @@ shared_object: $(PACKSODIR)/rocksdb4pl.$(SOEXT)
 
 $(PACKSODIR)/rocksdb4pl.$(SOEXT): cpp/rocksdb4pl.cpp $(LIBROCKSDB) Makefile
 	mkdir -p $(PACKSODIR)
+	@# For development:
+	@#   PACKSODIR=/tmp/rocksdb-so
+	@#   SOEXT=so
+	@#   CFLAGS='-fPIC -pthread -I$$HOME/src/swipl-devel/src -I$$HOME/src/swipl-devel/src/os -I$$HOME/src/swipl-devel/packages/cpp'
+	@# other flags: CPPFLAGS $(CPPFLAGS) LIBROCKSDB $(LIBROCKSDB) PLATFORM_LDFLAGS $(PLATFORM_LDFLAGS)
+	@#              SWISOLIB $(SWISOLIB) CFLAGS$(CFLAGS) COFLAGS $(COFLAGS) LDSOFLAGS$(LDSOFLAGS)
 	$(CXX) $(CPPFLAGS) -shared -o $@ cpp/rocksdb4pl.cpp $(LIBROCKSDB) $(PLATFORM_LDFLAGS) $(SWISOLIB)
 
 install::

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Should do the trick. Note that this clones RocksDB and builds it the way
 we need the library. This requires   significant  disk space (1.4Gb) and
 takes long (several minutes on a modern machine).
 
+This code depends on version 2 of the `SWI-cpp.h` file that is part of
+SWI-Prolog version 8.5.16 and later.
+
 #### Why are you not using the pre-built librocksdb?
 
 There are a  number  of  issues   with  several  pre-built  versions  of

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ we need the library. This requires   significant  disk space (1.4Gb) and
 takes long (several minutes on a modern machine).
 
 This code depends on version 2 of the `SWI-cpp.h` file that is part of
-SWI-Prolog version 8.5.16 and later.
+SWI-Prolog version 9.1.0 and later.
 
 #### Why are you not using the pre-built librocksdb?
 

--- a/cpp/rocksdb4pl.cpp
+++ b/cpp/rocksdb4pl.cpp
@@ -72,8 +72,8 @@ typedef enum
 
 typedef struct dbref
 { rocksdb::DB	*db;			/* DB handle */
-  atom_t         symbol;		/* associated symbol */
-  atom_t	 name;			/* alias name */
+  PlAtom         symbol;		/* associated symbol */
+  PlAtom	 name;			/* alias name */
   int	         flags;			/* flags */
   merger_t	 builtin_merger;	/* C++ Merger */
   record_t	 merger;		/* merge option */
@@ -83,16 +83,27 @@ typedef struct dbref
   } type;
 } dbref;
 
+static dbref null_dbref =
+{ nullptr,	// rocksdb::DB	*db;
+  PlAtom(),	// PlAtom        symbol;
+  PlAtom(),	// PlAtom	 name;
+  0,		// int	         flags;
+  MERGE_NONE,	// merger_t	 builtin_merger;
+  nullptr,	// record_t	 merger;
+  { BLOB_ATOM,	//   blob_type	   key;
+    BLOB_ATOM	//   blob_type	   value;
+  }
+};
+
+
 
 		 /*******************************
 		 *	      ALIAS		*
 		 *******************************/
 
-#define NULL_ATOM (atom_t)0
-
 typedef struct alias_cell
-{ atom_t	name;
-  atom_t	symbol;
+{ PlAtom	name;
+  PlAtom	symbol;
   struct alias_cell *next;
 } alias_cell;
 
@@ -103,12 +114,12 @@ static unsigned int alias_size = ALIAS_HASH_SIZE;
 static alias_cell *alias_entries[ALIAS_HASH_SIZE];
 
 static unsigned int
-atom_hash(atom_t a)
-{ return (unsigned int)(a>>7) % alias_size;
+atom_hash(PlAtom a)
+{ return static_cast<unsigned int>(a.C_>>7) % alias_size;
 }
 
-static atom_t
-rocks_get_alias(atom_t name)
+static PlAtom
+rocks_get_alias(PlAtom name)
 { for(alias_cell *c = alias_entries[atom_hash(name)];
       c;
       c = c->next)
@@ -116,34 +127,34 @@ rocks_get_alias(atom_t name)
       return c->symbol;
   }
 
-  return NULL_ATOM;
+  return PlAtom();
 }
 
 static void
-rocks_alias(atom_t name, atom_t symbol)
+rocks_alias(PlAtom name, PlAtom symbol)
 { auto key = atom_hash(name);
 
   alias_lock.lock();
-  if ( !rocks_get_alias(name) )
+  if ( !rocks_get_alias(name).not_null() )
   { alias_cell *c = static_cast<alias_cell *>(malloc(sizeof *c));
 
     c->name   = name;
     c->symbol = symbol;
     c->next   = alias_entries[key];
     alias_entries[key] = c;
-    PL_register_atom(c->name);
-    PL_register_atom(c->symbol);
+    c->name.register_ref();
+    c->symbol.register_ref();
     alias_lock.unlock();
   } else
   { alias_lock.unlock();
-    throw PlPermissionError("alias", "rocksdb", PlTerm(name));
+    throw PlPermissionError("alias", "rocksdb", PlTerm_atom(name));
   }
 }
 
 static void
-rocks_unalias(atom_t name)
+rocks_unalias(PlAtom name)
 { auto key = atom_hash(name);
-  alias_cell *c, *prev=NULL;
+  alias_cell *c, *prev=nullptr;
 
   alias_lock.lock();
   for(c = alias_entries[key]; c; prev=c, c = c->next)
@@ -152,8 +163,8 @@ rocks_unalias(atom_t name)
 	prev->next = c->next;
       else
 	alias_entries[key] = c->next;
-      PL_unregister_atom(c->name);
-      PL_unregister_atom(c->symbol);
+      c->name.unregister_ref();
+      c->symbol.unregister_ref();
       free(c);
 
       break;
@@ -167,14 +178,20 @@ rocks_unalias(atom_t name)
 		 *	 SYMBOL REFERENCES	*
 		 *******************************/
 
-static int
-write_rocks_ref(IOSTREAM *s, atom_t eref, int flags)
-{ auto refp = static_cast<dbref **>(PL_blob_data(eref, NULL, NULL));
+static bool
+write_rocks_ref_(IOSTREAM *s, PlAtom eref, int flags)
+{ auto refp = static_cast<dbref **>(eref.blob_data(nullptr, nullptr));
   auto ref  = *refp;
-  (void)flags;
 
   Sfprintf(s, "<rocksdb>(%p)", ref);
-  return TRUE;
+  if ( flags&PL_WRT_NEWLINE )
+    Sfprintf(s, "\n");
+  return true;
+}
+
+static int // TODO: bool
+write_rocks_ref(IOSTREAM *s, atom_t eref, int flags)
+{ return write_rocks_ref_(s, PlAtom(eref), flags);
 }
 
 
@@ -182,16 +199,16 @@ write_rocks_ref(IOSTREAM *s, atom_t eref, int flags)
 GC an rocks from the atom garbage collector.
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-static int
-release_rocks_ref(atom_t aref)
-{ auto refp = static_cast<dbref **>(PL_blob_data(aref, NULL, NULL));
+static bool
+release_rocks_ref_(PlAtom aref)
+{ auto refp = static_cast<dbref **>(aref.blob_data(nullptr, nullptr));
   auto ref  = *refp;
 
-  assert(ref->name == NULL_ATOM);
+  assert(ref->name.is_null());
 
   { auto db = ref->db;
     if ( db )
-    { ref->db = NULL;
+    { ref->db = nullptr;
       delete db;
     }
   }
@@ -201,98 +218,107 @@ release_rocks_ref(atom_t aref)
   }
   PL_free(ref);
 
-  return TRUE;
+  return true;
 }
 
+static int // TODO: bool
+release_rocks_ref(atom_t aref)
+{ return release_rocks_ref_(PlAtom(aref));
+}
 
-static int
-save_rocks(atom_t aref, IOSTREAM *fd)
-{ auto refp = static_cast<dbref **>(PL_blob_data(aref, NULL, NULL));
+static bool
+save_rocks_(PlAtom aref, IOSTREAM *fd)
+{ auto refp = static_cast<dbref **>(aref.blob_data(nullptr, nullptr));
   auto ref  = *refp;
   (void)fd;
 
   return PL_warning("Cannot save reference to <rocksdb>(%p)", ref);
 }
 
+static int // TODO: bool
+save_rocks(atom_t aref, IOSTREAM *fd)
+{ return save_rocks_(PlAtom(aref), fd);
+}
+
+static PlAtom
+load_rocks_(IOSTREAM *fd)
+{ (void)fd;
+
+  return PlAtom("<saved-rocksdb-ref>");
+}
 
 static atom_t
 load_rocks(IOSTREAM *fd)
-{ (void)fd;
-
-  return PL_new_atom("<saved-rocksdb-ref>");
+{ return load_rocks_(fd).C_;
 }
-
 
 static PL_blob_t rocks_blob =
 { PL_BLOB_MAGIC,
   PL_BLOB_UNIQUE,
   (const char *)"rocksdb",
   release_rocks_ref,
-  NULL,
+  nullptr,
   write_rocks_ref,
-  NULL,
-  save_rocks,
-  load_rocks
+  nullptr,
+  save_rocks, // TODO: needs to be implemented
+  load_rocks  // TODO: needs to be implemented
 };
 
 
-static int
-unify_rocks(term_t t, dbref *ref)
-{ if ( ref->name )
-  { if ( !ref->symbol )
-    { PlTerm tmp;
-
-      if ( PL_unify_blob(tmp, &ref, sizeof ref, &rocks_blob) &&
-	   PL_get_atom(tmp, &ref->symbol) )
-      { rocks_alias(ref->name, ref->symbol);
-      } else
-      { assert(0);
-      }
+static bool
+unify_rocks(PlTerm t, dbref *ref)
+{ if ( ref->name.not_null() )
+  { if ( ref->symbol.is_null() )
+    { PlTerm_var tmp;
+      tmp.unify_blob_ex(&ref, sizeof ref, &rocks_blob);
+      ref->symbol = t.atom();
+      rocks_alias(ref->name, ref->symbol);
     }
-    return PL_unify_atom(t, ref->name);
-  } else if ( ref->symbol )
-  { return PL_unify_atom(t, ref->symbol);
-  } else
-  { return ( PL_unify_blob(t, &ref, sizeof ref, &rocks_blob) &&
-	     PL_get_atom(t, &ref->symbol)
-	   );
-  }
+    return t.unify_atom(ref->name);
+  } else if ( ref->symbol.not_null() )
+  { return t.unify_atom(ref->symbol);
+  } else return ( t.unify_blob(&ref, sizeof ref, &rocks_blob) &&
+                  t.get_if_atom(&ref->symbol) );
 }
 
 
 static dbref*
-symbol_dbref(atom_t symbol)
+symbol_dbref(PlAtom symbol)
 { void *data;
   size_t len;
   PL_blob_t *type;
 
-  if ( (data=PL_blob_data(symbol, &len, &type)) && type == &rocks_blob )
+  if ( (data=symbol.blob_data(&len, &type)) && type == &rocks_blob )
   { auto erd = static_cast<dbref **>(data);
     return *erd;
   }
 
-  return static_cast<dbref *>(NULL);
+  return static_cast<dbref *>(nullptr);
 }
 
 
-static int
-get_rocks(term_t t, dbref **erp, int warn=TRUE)
-{ atom_t a;
+static bool
+get_rocks(PlTerm t, dbref **erp, bool warn=true)
+{ PlAtom a;
 
-  if ( PL_get_atom(t, &a) )
-  { for(int i=0; i<2; i++)
+  if ( warn )
+    a = t.atom();
+  else
+    (void)t.get_if_atom(&a);
+  if ( t.not_null() )
+  { for(int i=0; i<2 && a.not_null(); i++)
     { dbref *ref;
 
       if ( (ref=symbol_dbref(a)) )
       { if ( !(ref->flags & DB_DESTROYED) )
 	{ *erp = ref;
-	  return TRUE;
+	  return true;
 	} else if ( warn )
-	{ throw PlExistenceError("rocksdb", t);
+        { throw PlExistenceError("rocksdb", t);
 	}
       }
 
-      a=rocks_get_alias(a);
+      a = rocks_get_alias(a);
     }
 
     throw PlExistenceError("rocksdb", t);
@@ -301,7 +327,7 @@ get_rocks(term_t t, dbref **erp, int warn=TRUE)
   if ( warn )
     throw PlTypeError("rocksdb", t);
 
-  return FALSE;
+  return false;
 }
 
 
@@ -315,19 +341,19 @@ public:
   RocksError(const rocksdb::Status &status) :
     PlException(PlCompound("error",
 			   PlTermv(PlCompound("rocks_error",
-					      PlTerm(status.ToString().c_str())),
-				   PlTerm())))
+					      PlTermv(PlTerm_atom(status.ToString()))),
+				   PlTerm_var())))
   {
   }
 };
 
 
-static int
+static bool
 ok(const rocksdb::Status &status)
 { if ( status.ok() )
-    return TRUE;
+    return true;
   if ( status.IsNotFound() )
-    return FALSE;
+    return false;
   throw RocksError(status);
 }
 
@@ -336,7 +362,7 @@ class PlSlice : public Slice
 public:
   int must_free = 0;
   union
-  { int     i32;  // int32_t
+  { int32_t i32;
     int64_t i64;
     float   f32;
     double  f64;
@@ -346,7 +372,7 @@ public:
   { if ( must_free )
       PL_erase_external(const_cast<char *>(data_));
     must_free = 0;
-    data_ = NULL;
+    data_ = nullptr;
     size_ = 0;
   }
 
@@ -360,69 +386,52 @@ public:
 #define CVT_IN	(CVT_ATOM|CVT_STRING|CVT_LIST)
 
 static void
-get_slice(term_t t, PlSlice &s, blob_type type)
+get_slice(PlTerm t, PlSlice &s, blob_type type)
 { char *str;
   size_t len;
 
   switch(type)
   { case BLOB_ATOM:
     case BLOB_STRING:
-      if ( PL_get_nchars(t, &len, &str, CVT_IN|CVT_EXCEPTION|REP_UTF8) )
-      { s.data_ = str;
-	s.size_ = len;
-	return;
-      }
-      throw(PlException(PL_exception(0)));
+      t.nchars(&len, &str, CVT_IN|CVT_EXCEPTION|REP_UTF8);
+      s.data_ = str;
+      s.size_ = len;
+      return;
     case BLOB_BINARY:
-      if ( PL_get_nchars(t, &len, &str, CVT_IN|CVT_EXCEPTION) )
-      { s.data_ = str;
-	s.size_ = len;
-	return;
-      }
-      throw(PlException(PL_exception(0)));
+      t.nchars(&len, &str, CVT_IN|CVT_EXCEPTION);
+      s.data_ = str;
+      s.size_ = len;
+      return;
     case BLOB_INT32:
-    { if ( PL_get_integer_ex(t, &s.v.i32) )
-      { s.data_ = reinterpret_cast<const char *>(&s.v.i32);
-	s.size_ = sizeof s.v.i32;
-	return;
-      }
-      throw(PlException(PL_exception(0)));
-    }
+      t.integer(&s.v.i32);
+      s.data_ = reinterpret_cast<const char *>(&s.v.i32);
+      s.size_ = sizeof s.v.i32;
+      return;
     case BLOB_INT64:
-    { if ( PL_get_int64_ex(t, &s.v.i64) )
-      { s.data_ = reinterpret_cast<const char *>(&s.v.i64);
-	s.size_ = sizeof s.v.i64;
-	return;
-      }
-      throw(PlException(PL_exception(0)));
-    }
+      t.integer(&s.v.i64);
+      s.data_ = reinterpret_cast<const char *>(&s.v.i64);
+      s.size_ = sizeof s.v.i64;
+      return;
     case BLOB_FLOAT32:
-    { double d;
-
-      if ( PL_get_float_ex(t, &d) )
-      { s.v.f32 = d;
+      { double d = t.get_float();
+        s.v.f32 = d;
 	s.data_ = reinterpret_cast<const char *>(&s.v.f32);
 	s.size_ = sizeof s.v.f32 ;
 	return;
       }
-      throw(PlException(PL_exception(0)));
-    }
     case BLOB_FLOAT64:
-    { if ( PL_get_float_ex(t, &s.v.f64) )
-      { s.data_ = reinterpret_cast<const char*>(&s.v.f64);
-	s.size_ = sizeof s.v.f64;
-	return;
-      }
-      throw(PlException(PL_exception(0)));
-    }
+      s.v.f64 = t.get_float();
+      s.data_ = reinterpret_cast<const char*>(&s.v.f64);
+      s.size_ = sizeof s.v.f64;
+      return;
     case BLOB_TERM:
-      if ( (str=PL_record_external(t, &len)) )
+      if ( (str=PL_record_external(t.C_, &len)) )
       { s.data_ = str;
 	s.size_ = len;
 	s.must_free = TRUE;
 	return;
       }
-      throw(PlException(PL_exception(0)));
+      throw PlException(PlTerm::exception(0));
     default:
       assert(0);
   }
@@ -432,95 +441,95 @@ get_slice(term_t t, PlSlice &s, blob_type type)
 static const PlAtom ATOM_("");
 
 
-static int
-unify(term_t t, const Slice &s, blob_type type)
+static bool
+unify(PlTerm t, const Slice &s, blob_type type)
 { switch(type)
   { case BLOB_ATOM:
-      return PL_unify_chars(t, PL_ATOM|REP_UTF8, s.size_, s.data_);
+      return t.unify_chars(PL_ATOM|REP_UTF8, s.size_, s.data_);
     case BLOB_STRING:
-      return PL_unify_chars(t, PL_STRING|REP_UTF8, s.size_, s.data_);
+
+      return t.unify_chars(PL_STRING|REP_UTF8, s.size_, s.data_);
     case BLOB_BINARY:
-      return PL_unify_chars(t, PL_STRING|REP_ISO_LATIN_1, s.size_, s.data_);
+      return t.unify_chars(PL_STRING|REP_ISO_LATIN_1, s.size_, s.data_);
     case BLOB_INT32:
     { int i;
 
       memcpy(&i, s.data_, sizeof i); // Unaligned i=*reinterpret_cast<int>(s.data_)
-      return PL_unify_integer(t, i);
+      return t.unify_integer(i);
     }
     case BLOB_INT64:
     { int64_t i;
 
       memcpy(&i, s.data_, sizeof i);
-      return PL_unify_int64(t, i);
+      return t.unify_integer(i);
     }
     case BLOB_FLOAT32:
     { float f;
 
       memcpy(&f, s.data_, sizeof f);
-      return PL_unify_float(t, f);
+      return t.unify_float(f);
     }
     case BLOB_FLOAT64:
     { double f;
 
       memcpy(&f, s.data_, sizeof f);
-      return PL_unify_float(t, f);
+      return t.unify_float(f);
     }
     case BLOB_TERM:
-    { PlTerm tmp;
+    { PlTerm_var tmp;
 
-      return ( PL_recorded_external(s.data_, tmp) &&
-	       PL_unify(tmp, t)
+      return ( PL_recorded_external(s.data_, tmp.C_) &&
+	       tmp.unify_term(t)
 	     );
     }
     default:
       assert(0);
-      return FALSE;
+      return false;
   }
 }
 
-static int
-unify(term_t t, const Slice *s, blob_type type)
-{ if ( s == static_cast<const Slice *>(NULL) )
+static bool
+unify(PlTerm t, const Slice *s, blob_type type)
+{ if ( s == static_cast<const Slice *>(nullptr) )
   { switch(type)
     { case BLOB_ATOM:
-	return PL_unify_atom(t, ATOM_.handle);
+	return t.unify_atom(ATOM_);
       case BLOB_STRING:
       case BLOB_BINARY:
-	return PL_unify_chars(t, PL_STRING, 0, "");
+	return t.unify_chars(PL_STRING, 0, "");
       case BLOB_INT32:
       case BLOB_INT64:
-	return PL_unify_integer(t, 0);
+	return t.unify_integer(0);
       case BLOB_FLOAT32:
       case BLOB_FLOAT64:
-	return PL_unify_float(t, 0.0);
+	return t.unify_float(0.0);
       case BLOB_TERM:
-	return PL_unify_nil(t);
+	return t.unify_nil();
       default:
 	assert(0);
-	return FALSE;
+	return false;
     }
   }
 
   return unify(t, *s, type);
 }
 
-static int
-unify(term_t t, const std::string &s, blob_type type)
+static bool
+unify(PlTerm t, const std::string &s, blob_type type)
 { Slice sl(s.data(), s.length());
 
   return unify(t, sl, type);
 }
 
-static int
-unify_value(term_t t, const Slice &s, merger_t merge, blob_type type)
+static bool
+unify_value(PlTerm t, const Slice &s, merger_t merge, blob_type type)
 { if ( merge == MERGE_NONE )
   { return unify(t, s, type);
   } else
-  { PlTail list(t);
-    PlTerm tmp;
+  { PlTerm_tail list(t);
+    PlTerm_var tmp;
     const char *data = s.data();
     const char *end  = data+s.size();
-    int rc;
 
     while(data < end)
     { switch( type )
@@ -528,45 +537,49 @@ unify_value(term_t t, const Slice &s, merger_t merge, blob_type type)
 	{ int i;
 	  memcpy(&i, data, sizeof i);
 	  data += sizeof i;
-	  rc = PL_put_integer(tmp, i);
-	  break;
+	  if ( !PL_put_integer(tmp.C_, i) )
+            return false;
 	}
+        break;
 	case BLOB_INT64:
 	{ int64_t i;
 	  memcpy(&i, data, sizeof i);
 	  data += sizeof i;
-	  rc = PL_put_int64(tmp, i);
-	  break;
+	  if ( !PL_put_int64(tmp.C_, i) )
+            return false;
 	}
+        break;
 	case BLOB_FLOAT32:
 	{ float i;
 	  memcpy(&i, data, sizeof i);
 	  data += sizeof i;
-	  rc = PL_put_float(tmp, i);
-	  break;
+	  if ( !PL_put_float(tmp.C_, i) )
+            return false;
 	}
+        break;
 	case BLOB_FLOAT64:
 	{ double i;
 	  memcpy(&i, data, sizeof i);
 	  data += sizeof i;
-	  rc = PL_put_float(tmp, i);
-	  break;
+	  if ( !PL_put_float(tmp.C_, i) )
+            return false;
 	}
+        break;
 	default:
 	  assert(0);
-	  rc = FALSE;
+          return false;
       }
 
       if ( !list.append(tmp) )
-	return FALSE;
+	return false;
     }
 
     return list.close();
   }
 }
 
-static int
-unify_value(term_t t, const std::string &s, merger_t merge, blob_type type)
+static bool
+unify_value(PlTerm t, const std::string &s, merger_t merge, blob_type type)
 { Slice sl(s.data(), s.length());
 
   return unify_value(t, sl, merge, type);
@@ -580,11 +593,11 @@ unify_value(term_t t, const std::string &s, merger_t merge, blob_type type)
 static const PlAtom ATOM_partial("partial");
 static const PlAtom ATOM_full("full");
 
-static int
+static bool
 log_exception(Logger* logger)
-{ PlException ex(PL_exception(0));
+{ PlException ex(PlTerm::exception(0));
 
-  Log(logger, "%s", static_cast<const char *>(ex));
+  Log(logger, "%s", ex.c_str());
   return false;
 }
 
@@ -594,13 +607,12 @@ class engine
 public:
   engine()
   { if ( PL_thread_self() == -1 )
-    { if ( (tid=PL_thread_attach_engine(NULL)) < 0 )
-      { term_t ex;
-
-	if ( (ex = PL_exception(0)) )
-	  PlException(ex).cppThrow();
-	else
-	  throw PlResourceError("memory");
+    { if ( (tid=PL_thread_attach_engine(nullptr)) < 0 )
+    { auto ex = PlTerm::exception(0);
+      if ( ex.not_null() )
+        throw PlException(ex).adjust_for_throw();
+      else
+        throw PlResourceError("memory");
       }
     }
   }
@@ -611,10 +623,10 @@ public:
   }
 };
 
-static int
+static bool
 call_merger(const dbref *ref, PlTermv av, std::string* new_value,
 	    Logger* logger)
-{ static predicate_t pred_call6 = NULL;
+{ static predicate_t pred_call6 = nullptr;
 
   if ( !pred_call6 )
     pred_call6 = PL_predicate("call", 6, "system");
@@ -632,7 +644,7 @@ call_merger(const dbref *ref, PlTermv av, std::string* new_value,
       return false;
     }
   } catch(PlException &ex)
-  { Log(logger, "%s", static_cast<const char *>(ex));
+    { Log(logger, "%s", ex.c_str());
     return false;
   }
 }
@@ -653,18 +665,18 @@ public:
 	    Logger* logger) const override
   { engine e;
     PlTermv av(6);
-    PlTail list(av[4]);
-    PlTerm tmp;
+    PlTerm_tail list(av[4]);
+    PlTerm_var tmp;
 
     for (const auto& value : operand_list)
-    { PL_put_variable(tmp);
+    { PL_put_variable(tmp.C_);
       unify(tmp, value, ref->type.value);
       list.append(tmp);
     }
     list.close();
 
-    if ( PL_recorded(ref->merger, av[0]) &&
-	 (av[1] = ATOM_full) &&
+    if ( PL_recorded(ref->merger, av[0].C_) &&
+	 av[1].unify_atom(ATOM_full) &&
 	 unify(av[2], key, ref->type.key) &&
 	 unify(av[3], existing_value, ref->type.value) )
       return call_merger(ref, av, new_value, logger);
@@ -681,8 +693,8 @@ public:
   { engine e;
     PlTermv av(6);
 
-    if ( PL_recorded(ref->merger, av[0]) &&
-	 (av[1] = ATOM_partial) &&
+    if ( PL_recorded(ref->merger, av[0].C_) &&
+	 av[1].unify_atom(ATOM_partial) &&
 	 unify(av[2], key, ref->type.key) &&
 	 unify(av[3], left_operand, ref->type.value) &&
 	 unify(av[4], right_operand, ref->type.value) )
@@ -794,7 +806,9 @@ public:
 	    const std::deque<std::string>& operand_list,
 	    std::string* new_value,
 	    Logger* logger) const override
-  { std::string s;
+  { (void)key;
+    (void)logger;
+    std::string s;
 
     if ( existing_value )
       s += existing_value->ToString();
@@ -815,7 +829,9 @@ public:
 	       const Slice& right_operand,
 	       std::string* new_value,
 	       Logger* logger) const override
-  { std::string s = left_operand.ToString();
+  { (void)key;
+    (void)logger;
+    std::string s = left_operand.ToString();
     s += right_operand.ToString();
 
     if ( ref->builtin_merger == MERGE_SET )
@@ -866,17 +882,17 @@ static const PlFunctor FUNCTOR_set1("set", 1);
 
 static void
 get_blob_type(PlTerm t, blob_type *key_type, merger_t *m)
-{ atom_t a;
-  int rc;
+{ PlAtom a;
+  bool rc;
 
-  if ( m && PL_is_functor(t, FUNCTOR_list1) )
+  if ( m && t.is_functor(FUNCTOR_list1) )
   { *m = MERGE_LIST;
-    rc = PL_get_atom(t[1], &a);
-  } else if ( m && PL_is_functor(t, FUNCTOR_set1) )
+    rc = t[1].get_if_atom(&a);
+  } else if ( m && t.is_functor(FUNCTOR_set1) )
   { *m = MERGE_SET;
-    rc = PL_get_atom(t[1], &a);
+    rc = t[1].get_if_atom(&a);
   } else
-    rc = PL_get_atom(t, &a);
+    rc = t.get_if_atom(&a);
 
   if ( rc )
   { if ( !m || *m == MERGE_NONE )
@@ -904,7 +920,7 @@ typedef void (*ReadOptdefAction)(rocksdb::ReadOptions *options, PlTerm t);
 struct ReadOptdef
 { const char *name;
   ReadOptdefAction action;
-  atom_t atom; // Initially 0; filled in as-needed by lookup
+  PlAtom atom; // Initially PlAtom::null; filled in as-needed by lookup
 };
 
 #define RD_ODEF [](rocksdb::ReadOptions *options, PlTerm arg)
@@ -914,29 +930,29 @@ static ReadOptdef read_optdefs[] =
   // "iterate_lower_bound" const Slice*
   // "iterate_upper_bound" const Slice*
   {         "readahead_size",                       RD_ODEF {
-    options->readahead_size                       = static_cast<size_t>(arg); } },
+    options->readahead_size                       = arg.get_size_t(); } },
   {         "max_skippable_internal_keys",          RD_ODEF {
-    options->max_skippable_internal_keys          = static_cast<uint64_t>(arg); } },
+    options->max_skippable_internal_keys          = arg.get_uint64_t(); } },
   // "read_tier" ReadTier
   {         "verify_checksums",                     RD_ODEF {
-    options->verify_checksums                     = static_cast<bool>(arg); } },
+    options->verify_checksums                     = arg.get_bool(); } },
   {         "fill_cache",                           RD_ODEF {
-    options->fill_cache                           = static_cast<bool>(arg); } },
+    options->fill_cache                           = arg.get_bool(); } },
   {         "tailing",                              RD_ODEF {
-    options->tailing                              = static_cast<bool>(arg); } },
+    options->tailing                              = arg.get_bool(); } },
   // "managed" - not used any more
   {         "total_order_seek",                     RD_ODEF {
-    options->total_order_seek                     = static_cast<bool>(arg); } },
+    options->total_order_seek                     = arg.get_bool(); } },
   {         "auto_prefix_mode",                     RD_ODEF {
-    options->auto_prefix_mode                     = static_cast<bool>(arg); } },
+    options->auto_prefix_mode                     = arg.get_bool(); } },
   {         "prefix_same_as_start",                 RD_ODEF {
-    options->prefix_same_as_start                 = static_cast<bool>(arg); } },
+    options->prefix_same_as_start                 = arg.get_bool(); } },
   {         "pin_data",                             RD_ODEF {
-    options->pin_data                             = static_cast<bool>(arg); } },
+    options->pin_data                             = arg.get_bool(); } },
   {         "background_purge_on_iterator_cleanup", RD_ODEF {
-    options->background_purge_on_iterator_cleanup = static_cast<bool>(arg); } },
+    options->background_purge_on_iterator_cleanup = arg.get_bool(); } },
   {         "ignore_range_deletions",               RD_ODEF {
-    options->ignore_range_deletions               = static_cast<bool>(arg); } },
+    options->ignore_range_deletions               = arg.get_bool(); } },
   // "table_filter" std::function<bool(const TableProperties&)>
   // TODO: "iter_start_seqnum" removed from rocksdb/include/options.h?
   // {         "iter_start_seqnum",                    RD_ODEF {
@@ -945,13 +961,12 @@ static ReadOptdef read_optdefs[] =
   // "iter_start_ts" Slice*
   {
              "deadline",                            RD_ODEF {
-    options->deadline                             = static_cast<std::chrono::microseconds>(arg); } },
+      options->deadline                             = static_cast<std::chrono::microseconds>(arg.get_int64_t()); } },
   {         "io_timeout",                           RD_ODEF {
-    options->io_timeout                           = static_cast<std::chrono::microseconds>(arg); } },
+      options->io_timeout                           = static_cast<std::chrono::microseconds>(arg.get_int64_t()); } },
   {         "value_size_soft_limit",                RD_ODEF {
-    options->value_size_soft_limit                = static_cast<uint64_t>(arg); } },
-
-  { NULL }
+      options->value_size_soft_limit                = arg.get_uint64_t(); } },
+  { nullptr }
 };
 
 
@@ -962,10 +977,10 @@ static ReadOptdef read_optdefs[] =
 static void
 lookup_read_optdef_and_apply(rocksdb::ReadOptions *options,
 			     ReadOptdef opt_defs[],
-			     atom_t name, PlTerm opt)
+			     PlAtom name, PlTerm opt)
 { for(auto def=opt_defs; def->name; def++)
-  { if ( !def->atom ) // lazilly fill in atoms in lookup table
-      def->atom = PL_new_atom(def->name);
+  { if ( def->atom.is_null() ) // lazilly fill in atoms in lookup table
+      def->atom = PlAtom(def->name);
     if ( def->atom == name )
     { def->action(options, opt[1]);
       return;
@@ -980,37 +995,37 @@ typedef void (*WriteOptdefAction)(rocksdb::WriteOptions *options, PlTerm t);
 struct WriteOptdef
 { const char *name;
   WriteOptdefAction action;
-  atom_t atom; // Initially 0; filled in as-needed by lookup
+  PlAtom atom; // Initially PlAtom::null; filled in as-needed by lookup
 };
 
 #define WR_ODEF [](rocksdb::WriteOptions *options, PlTerm arg)
 
 static WriteOptdef write_optdefs[] =
 { {         "sync",                           WR_ODEF {
-    options->sync                           = static_cast<bool>(arg); } },
+    options->sync                           = arg.get_bool(); } },
   {         "disableWAL",                     WR_ODEF {
-    options->disableWAL                     = static_cast<bool>(arg); } },
+    options->disableWAL                     = arg.get_bool(); } },
   {         "ignore_missing_column_families", WR_ODEF {
-    options->ignore_missing_column_families = static_cast<bool>(arg); } },
+    options->ignore_missing_column_families = arg.get_bool(); } },
   {         "no_slowdown",                    WR_ODEF {
-    options->no_slowdown                    = static_cast<bool>(arg); } },
+    options->no_slowdown                    = arg.get_bool(); } },
   {         "low_pri",                        WR_ODEF {
-    options->low_pri                        = static_cast<bool>(arg); } },
+    options->low_pri                        = arg.get_bool(); } },
   {         "memtable_insert_hint_per_batch", WR_ODEF {
-    options->memtable_insert_hint_per_batch = static_cast<bool>(arg); } },
+    options->memtable_insert_hint_per_batch = arg.get_bool(); } },
   // "timestamp" Slice*
 
-{ NULL }
+  { nullptr }
 };
 
 
 static void
 lookup_write_optdef_and_apply(rocksdb::WriteOptions *options,
 			      WriteOptdef opt_defs[],
-			      atom_t name, PlTerm opt)
+			      PlAtom name, PlTerm opt)
 { for(auto def=opt_defs; def->name; def++)
-  { if ( !def->atom ) // lazilly fill in atoms in lookup table
-      def->atom = PL_new_atom(def->name);
+  { if ( def->atom.is_null() ) // lazilly fill in atoms in lookup table
+      def->atom = PlAtom(def->name);
     if ( def->atom == name )
     { def->action(options, opt[1]);
       return;
@@ -1039,195 +1054,195 @@ typedef void (*OptdefAction)(rocksdb::Options *options, PlTerm t);
 struct Optdef
 { const char *name;
   OptdefAction action;
-  atom_t atom; // Initially 0; filled in as-needed by lookup
+  PlAtom atom; // Initially PlAtom::null; filled in as-needed by lookup
 };
 
 #define ODEF [](rocksdb::Options *options, PlTerm arg)
 
 static Optdef optdefs[] =
-{ { "prepare_for_bulk_load",                           ODEF { if ( static_cast<bool>(arg) ) options->PrepareForBulkLoad(); } }, // TODO: what to do with false?
-  { "optimize_for_small_db",                           ODEF { if ( static_cast<bool>(arg) ) options->OptimizeForSmallDb(); } }, // TODO: what to do with false? - there's no DontOptimizeForSmallDb()
+{ { "prepare_for_bulk_load",                           ODEF { if ( arg.get_bool() ) options->PrepareForBulkLoad(); } }, // TODO: what to do with false?
+  { "optimize_for_small_db",                           ODEF { if ( arg.get_bool() ) options->OptimizeForSmallDb(); } }, // TODO: what to do with false? - there's no DontOptimizeForSmallDb()
 #ifndef ROCKSDB_LITE
-  { "increase_parallelism",                            ODEF { if ( static_cast<bool>(arg) ) options->IncreaseParallelism(); } },
+  { "increase_parallelism",                            ODEF { if ( arg.get_bool() ) options->IncreaseParallelism(); } },
 #endif
   {         "create_if_missing",                       ODEF {
-    options->create_if_missing                       = static_cast<bool>(arg); } },
+    options->create_if_missing                       = arg.get_bool(); } },
   {         "create_missing_column_families",          ODEF {
-    options->create_missing_column_families          = static_cast<bool>(arg); } },
+    options->create_missing_column_families          = arg.get_bool(); } },
   {         "error_if_exists",                         ODEF {
-    options->error_if_exists                         = static_cast<bool>(arg); } },
+    options->error_if_exists                         = arg.get_bool(); } },
   {         "paranoid_checks",                         ODEF {
-    options->paranoid_checks                         = static_cast<bool>(arg); } },
+    options->paranoid_checks                         = arg.get_bool(); } },
   {         "track_and_verify_wals_in_manifest",       ODEF {
-    options->track_and_verify_wals_in_manifest       = static_cast<bool>(arg); } },
+    options->track_and_verify_wals_in_manifest       = arg.get_bool(); } },
   // "env" Env::Default
   // "rate_limiter" - shared_ptr<RateLimiter>
   // "sst_file_manager" - shared_ptr<SstFileManager>
   // "info_log" - shared_ptr<Logger> - see comment in ../README.md
   { "info_log_level",                                  options_set_InfoLogLevel },
   {         "max_open_files",                          ODEF {
-    options->max_open_files                          = static_cast<int>(arg); } },
+    options->max_open_files                          = arg.get_int(); } },
   {         "max_file_opening_threads",                ODEF {
-    options-> max_file_opening_threads               = static_cast<int>(arg); } },
+    options-> max_file_opening_threads               = arg.get_int(); } },
   {         "max_total_wal_size",                      ODEF {
-    options->max_total_wal_size                      = static_cast<uint64_t>(arg); } },
+    options->max_total_wal_size                      = arg.get_uint64_t(); } },
   {         "statistics",                              ODEF {
-    options->statistics = static_cast<bool>(arg) ? CreateDBStatistics() : nullptr; } },
+    options->statistics = arg.get_bool() ? CreateDBStatistics() : nullptr; } },
   {         "use_fsync",                               ODEF {
-    options->use_fsync                               = static_cast<bool>(arg); } },
+    options->use_fsync                               = arg.get_bool(); } },
   // "db_paths" - vector<DbPath>
   {         "db_log_dir",                              ODEF {
-    options->db_log_dir                              = static_cast<std::string>(arg); } },
+    options->db_log_dir                              = arg.string(); } },
   {         "wal_dir",                                 ODEF {
-    options->wal_dir                                 = static_cast<std::string>(arg); } },
+    options->wal_dir                                 = arg.string(); } },
   {         "delete_obsolete_files_period_micros",     ODEF {
-    options->delete_obsolete_files_period_micros     = static_cast<uint64_t>(arg); } },
+    options->delete_obsolete_files_period_micros     = arg.get_uint64_t(); } },
   {         "max_background_jobs",                     ODEF {
-    options->max_background_jobs                     = static_cast<uint64_t>(arg); } },
+    options->max_background_jobs                     = arg.get_uint64_t(); } },
   // "base_background_compactions" is obsolete
   // "max_background_compactions" is obsolete
   {         "max_subcompactions",                      ODEF {
-    options->max_subcompactions                      = static_cast<uint32_t>(arg); } },
+    options->max_subcompactions                      = arg.get_uint32_t(); } },
   // "max_background_flushes" is obsolete
   {         "max_log_file_size",                       ODEF {
-    options->max_log_file_size                       = static_cast<size_t>(arg); } },
+    options->max_log_file_size                       = arg.get_size_t(); } },
   {         "log_file_time_to_roll",                   ODEF {
-    options->log_file_time_to_roll                   = static_cast<size_t>(arg); } },
+    options->log_file_time_to_roll                   = arg.get_size_t(); } },
   {         "keep_log_file_num",                       ODEF {
-    options->keep_log_file_num                       = static_cast<size_t>(arg); } },
+    options->keep_log_file_num                       = arg.get_size_t(); } },
   {         "recycle_log_file_num",                    ODEF {
-    options->recycle_log_file_num                    = static_cast<size_t>(arg); } },
+    options->recycle_log_file_num                    = arg.get_size_t(); } },
   {         "max_manifest_file_size",                  ODEF {
-    options->max_manifest_file_size                  = static_cast<uint64_t>(arg); } },
+    options->max_manifest_file_size                  = arg.get_uint64_t(); } },
   {         "table_cache_numshardbits",                ODEF {
-    options->table_cache_numshardbits                = static_cast<int>(arg); } },
+    options->table_cache_numshardbits                = arg.get_int(); } },
   {         "wal_ttl_seconds",                         ODEF {
-    options->WAL_ttl_seconds                         = static_cast<uint64_t>(arg); } },
+    options->WAL_ttl_seconds                         = arg.get_uint64_t(); } },
   {         "wal_size_limit_mb",                       ODEF {
-    options->WAL_size_limit_MB                       = static_cast<uint64_t>(arg); } },
+    options->WAL_size_limit_MB                       = arg.get_uint64_t(); } },
   {         "manifest_preallocation_size",             ODEF {
-    options->manifest_preallocation_size             = static_cast<size_t>(arg); } },
+    options->manifest_preallocation_size             = arg.get_size_t(); } },
   {         "allow_mmap_reads",                        ODEF {
-    options->allow_mmap_reads                        = static_cast<bool>(arg); } },
+    options->allow_mmap_reads                        = arg.get_bool(); } },
   {         "allow_mmap_writes",                       ODEF {
-    options->allow_mmap_writes                       = static_cast<bool>(arg); } },
+    options->allow_mmap_writes                       = arg.get_bool(); } },
   {         "use_direct_reads",                        ODEF {
-    options->use_direct_reads                        = static_cast<bool>(arg); } },
+    options->use_direct_reads                        = arg.get_bool(); } },
   {         "use_direct_io_for_flush_and_compaction",  ODEF {
-    options->use_direct_io_for_flush_and_compaction  = static_cast<bool>(arg); } },
+    options->use_direct_io_for_flush_and_compaction  = arg.get_bool(); } },
   {         "allow_fallocate",                         ODEF {
-    options->allow_fallocate                         = static_cast<bool>(arg); } },
+    options->allow_fallocate                         = arg.get_bool(); } },
   {         "is_fd_close_on_exec",                     ODEF {
-    options->is_fd_close_on_exec                     = static_cast<bool>(arg); } },
+    options->is_fd_close_on_exec                     = arg.get_bool(); } },
   // "skip_log_error_on_recovery" is obsolete
   {         "stats_dump_period_sec",                   ODEF {
-    options->stats_dump_period_sec                   = static_cast<unsigned int>(arg); } },
+    options->stats_dump_period_sec                   = arg.get_uint32_t(); } }, // TODO: match: unsigned int stats_dump_period_sec
   {         "stats_persist_period_sec",                ODEF {
-    options->stats_persist_period_sec                = static_cast<unsigned int>(arg); } },
+      options->stats_persist_period_sec                = arg.get_uint32_t(); } }, // TODO: match: unsigned int stats_persist_period_sec
   {         "persist_stats_to_disk",                   ODEF {
-    options->persist_stats_to_disk                   = static_cast<bool>(arg); } },
+    options->persist_stats_to_disk                   = arg.get_bool(); } },
   {         "stats_history_buffer_size",               ODEF {
-    options->stats_history_buffer_size               = static_cast<size_t>(arg); } },
+    options->stats_history_buffer_size               = arg.get_size_t(); } },
   {         "advise_random_on_open",                   ODEF {
-    options->advise_random_on_open                   = static_cast<bool>(arg); } },
+    options->advise_random_on_open                   = arg.get_bool(); } },
   {         "db_write_buffer_size",                    ODEF {
-    options->db_write_buffer_size                    = static_cast<size_t>(arg); } },
+    options->db_write_buffer_size                    = arg.get_size_t(); } },
   // "write_buffer_manager" - shared_ptr<WriteBufferManager>
   // "access_hint_on_compaction_start" - enum AccessHint
   // TODO: "new_table_reader_for_compaction_inputs"  removed from rocksdb/include/options.h?
   // {         "new_table_reader_for_compaction_inputs",  ODEF {
-  //   options->new_table_reader_for_compaction_inputs  = static_cast<bool>(arg); } },
+//   options->new_table_reader_for_compaction_inputs  = arg.get_bool(); } },
   {         "compaction_readahead_size",               ODEF {
-    options->compaction_readahead_size               = static_cast<size_t>(arg); } },
+    options->compaction_readahead_size               = arg.get_size_t(); } },
   {         "random_access_max_buffer_size",           ODEF {
-    options->random_access_max_buffer_size           = static_cast<size_t>(arg); } },
+    options->random_access_max_buffer_size           = arg.get_size_t(); } },
   {         "writable_file_max_buffer_size",           ODEF {
-    options->writable_file_max_buffer_size           = static_cast<size_t>(arg); } },
+    options->writable_file_max_buffer_size           = arg.get_size_t(); } },
   {         "use_adaptive_mutex",                      ODEF {
-    options->use_adaptive_mutex                      = static_cast<bool>(arg); } },
+    options->use_adaptive_mutex                      = arg.get_bool(); } },
   {         "bytes_per_sync",                          ODEF {
-    options->bytes_per_sync                          = static_cast<uint64_t>(arg); } },
+    options->bytes_per_sync                          = arg.get_uint64_t(); } },
   {         "wal_bytes_per_sync",                      ODEF {
-    options->wal_bytes_per_sync                      = static_cast<uint64_t>(arg); } },
+    options->wal_bytes_per_sync                      = arg.get_uint64_t(); } },
   {         "strict_bytes_per_sync",                   ODEF {
-    options->strict_bytes_per_sync                   = static_cast<bool>(arg); } },
+    options->strict_bytes_per_sync                   = arg.get_bool(); } },
   // "listeners" - vector<shared_ptr<EventListener>>
   {         "enable_thread_tracking",                  ODEF {
-    options->enable_thread_tracking                  = static_cast<bool>(arg); } },
+    options->enable_thread_tracking                  = arg.get_bool(); } },
   {         "delayed_write_rate",                      ODEF {
-    options->delayed_write_rate                      = static_cast<uint64_t>(arg); } },
+    options->delayed_write_rate                      = arg.get_uint64_t(); } },
   {         "enable_pipelined_write",                  ODEF {
-    options->enable_pipelined_write                  = static_cast<bool>(arg); } },
+    options->enable_pipelined_write                  = arg.get_bool(); } },
   {         "unordered_write",                         ODEF {
-    options->unordered_write                         = static_cast<bool>(arg); } },
+    options->unordered_write                         = arg.get_bool(); } },
   {         "allow_concurrent_memtable_write",         ODEF {
-    options->allow_concurrent_memtable_write         = static_cast<bool>(arg); } },
+    options->allow_concurrent_memtable_write         = arg.get_bool(); } },
   {         "enable_write_thread_adaptive_yield",      ODEF {
-    options->enable_write_thread_adaptive_yield      = static_cast<bool>(arg); } },
+    options->enable_write_thread_adaptive_yield      = arg.get_bool(); } },
   {         "max_write_batch_group_size_bytes",        ODEF {
-    options->max_write_batch_group_size_bytes        = static_cast<uint64_t>(arg); } },
+    options->max_write_batch_group_size_bytes        = arg.get_uint64_t(); } },
   {         "write_thread_max_yield_usec",             ODEF {
-    options->write_thread_max_yield_usec             = static_cast<uint64_t>(arg); } },
+    options->write_thread_max_yield_usec             = arg.get_uint64_t(); } },
   {         "write_thread_slow_yield_usec",            ODEF {
-    options->write_thread_slow_yield_usec            = static_cast<uint64_t>(arg); } },
+    options->write_thread_slow_yield_usec            = arg.get_uint64_t(); } },
   {         "skip_stats_update_on_db_open",            ODEF {
-    options->skip_stats_update_on_db_open            = static_cast<bool>(arg); } },
+    options->skip_stats_update_on_db_open            = arg.get_bool(); } },
   {         "skip_checking_sst_file_sizes_on_db_open", ODEF {
-    options->skip_checking_sst_file_sizes_on_db_open = static_cast<bool>(arg); } },
+    options->skip_checking_sst_file_sizes_on_db_open = arg.get_bool(); } },
   // "wal_recovery_mode" - enum WALRecoveryMode
   {         "allow_2pc",                               ODEF {
-    options->allow_2pc                               = static_cast<bool>(arg); } },
+    options->allow_2pc                               = arg.get_bool(); } },
   // "row_cache" - shared_ptr<Cache>
   // "wal_filter" - WalFilter*
   {         "fail_ifoptions_file_error",               ODEF {
-    options->fail_if_options_file_error              = static_cast<bool>(arg); } },
+    options->fail_if_options_file_error              = arg.get_bool(); } },
   {         "dump_malloc_stats",                       ODEF {
-    options->dump_malloc_stats                       = static_cast<bool>(arg); } },
+    options->dump_malloc_stats                       = arg.get_bool(); } },
   {         "avoid_flush_during_recovery",             ODEF {
-    options->avoid_flush_during_recovery             = static_cast<bool>(arg); } },
+    options->avoid_flush_during_recovery             = arg.get_bool(); } },
   {         "avoid_flush_during_shutdown",             ODEF {
-    options->avoid_flush_during_shutdown             = static_cast<bool>(arg); } },
+    options->avoid_flush_during_shutdown             = arg.get_bool(); } },
   {         "allow_ingest_behind",                     ODEF {
-    options->allow_ingest_behind                     = static_cast<bool>(arg); } },
+    options->allow_ingest_behind                     = arg.get_bool(); } },
   // TODO: "preserve_deletes" removed from rocksdb/include/options.h?
   // {         "preserve_deletes",                        ODEF {
-  //   options->preserve_deletes                        = static_cast<bool>(arg); } },
+//   options->preserve_deletes                        = arg.get_bool(); } },
   {         "two_write_queues",                        ODEF {
-    options->two_write_queues                        = static_cast<bool>(arg); } },
+    options->two_write_queues                        = arg.get_bool(); } },
   {         "manual_wal_flush",                        ODEF {
-    options->manual_wal_flush                        = static_cast<bool>(arg); } },
+    options->manual_wal_flush                        = arg.get_bool(); } },
   {         "atomic_flush",                            ODEF {
-    options->atomic_flush                            = static_cast<bool>(arg); } },
+    options->atomic_flush                            = arg.get_bool(); } },
   {         "avoid_unnecessary_blocking_io",           ODEF {
-    options->avoid_unnecessary_blocking_io           = static_cast<bool>(arg); } },
+    options->avoid_unnecessary_blocking_io           = arg.get_bool(); } },
   {         "write_dbid_to_manifest",                  ODEF {
-    options->write_dbid_to_manifest                  = static_cast<bool>(arg); } },
+    options->write_dbid_to_manifest                  = arg.get_bool(); } },
   {         "log_readahead_size",                      ODEF {
-    options->write_dbid_to_manifest                  = static_cast<bool>(arg); } },
+    options->write_dbid_to_manifest                  = arg.get_bool(); } },
   // "file_checksum_gen_factory" - std::shared_ptr<FileChecksumGenFactory>
   { "best_efforts_recovery",                           ODEF {
-    options->best_efforts_recovery                   = static_cast<bool>(arg); } },
+    options->best_efforts_recovery                   = arg.get_bool(); } },
   {         "max_bgerror_resume_count",                ODEF {
-    options->max_bgerror_resume_count                = static_cast<int>(arg); } },
+    options->max_bgerror_resume_count                = arg.get_int(); } },
   {         "bgerror_resume_retry_interval",           ODEF {
-    options->bgerror_resume_retry_interval           = static_cast<uint64_t>(arg); } },
+    options->bgerror_resume_retry_interval           = arg.get_uint64_t(); } },
   {         "allow_data_in_errors",                    ODEF {
-    options->allow_data_in_errors                    = static_cast<bool>(arg); } },
+    options->allow_data_in_errors                    = arg.get_bool(); } },
   {         "db_host_id",                              ODEF {
-    options->db_host_id                              = static_cast<std::string>(arg); } },
+      options->db_host_id                            = arg.string(); } },
   // "checksum_handoff_file_types" - FileTypeSet
 
-  { NULL }
+  { nullptr }
 };
 
 
 static void
 lookup_optdef_and_apply(rocksdb::Options *options,
 			Optdef opt_defs[],
-			atom_t name, PlTerm opt)
+			PlAtom name, PlTerm opt)
 { for(auto def=opt_defs; def->name; def++)
-  { if ( !def->atom ) // lazilly fill in atoms in lookup table
-      def->atom = PL_new_atom(def->name);
+  { if ( def->atom.is_null() ) // lazilly fill in atoms in lookup table
+      def->atom = PlAtom(def->name);
     if ( def->atom == name )
     { def->action(options, opt[1]);
       return;
@@ -1244,51 +1259,43 @@ PREDICATE(rocks_open_, 3)
   blob_type key_type   = BLOB_ATOM;
   blob_type value_type = BLOB_ATOM;
   merger_t builtin_merger = MERGE_NONE;
-  atom_t alias = NULL_ATOM;
+  PlAtom alias; // = PlAtom::null
   record_t merger = 0;
-  int once = FALSE;
-  int read_only = FALSE;
+  int once = false;
+  int read_only = false;
 
-  if ( !PL_get_file_name(A1, &fn, PL_FILE_OSPATH) )
-    return FALSE;
-  PlTail tail(A3);
-  PlTerm opt;
+  if ( !PL_get_file_name(A1.C_, &fn, PL_FILE_OSPATH) )
+    return false;
+  PlTerm_tail tail(A3);
+  PlTerm_var opt;
   while(tail.next(opt))
-  { atom_t name;
-    size_t arity;
+  { PlAtom name;
+    ARITY_T arity;
 
-    if ( PL_get_name_arity(opt, &name, &arity) && arity == 1 )
+    opt.name_arity(&name, &arity);
+    if (  arity == 1 )
     { if ( ATOM_key == name )
-	get_blob_type(opt[1], &key_type, static_cast<merger_t *>(NULL));
+	get_blob_type(opt[1], &key_type, static_cast<merger_t *>(nullptr));
       else if ( ATOM_value == name )
 	get_blob_type(opt[1], &value_type, &builtin_merger);
       else if ( ATOM_merge == name )
-	merger = PL_record(opt[1]);
+	merger = PL_record(opt[1].C_);
       else if ( ATOM_alias == name )
-      { if ( !PL_get_atom_ex(opt[1], &alias) )
-	  return FALSE;
-	once = TRUE;
+      { alias = opt[1].atom();
+	once = true;
       } else if ( ATOM_open == name )
-      { atom_t open;
-
-	if ( !PL_get_atom_ex(opt[1], &open) )
-	  return FALSE;
-	if ( ATOM_once == open )
-	  once = TRUE;
+      { if ( ATOM_once == opt[1].atom() )
+	  once = true;
 	else
 	  throw PlDomainError("open_option", opt[1]);
       } else if ( ATOM_mode == name )
-      { atom_t a;
-
-	if ( PL_get_atom(opt[1], &a) )
-	{ if ( ATOM_read_write == a )
-	    read_only = FALSE;
-	  else if ( ATOM_read_only == a )
-	    read_only = TRUE;
-	  else
-	    throw PlDomainError("mode_option", opt[1]);
-	} else
-	  throw PlTypeError("atom", opt[1]);
+      { PlAtom a = opt[1].atom();
+        if ( ATOM_read_write == a )
+	  read_only = false;
+        else if ( ATOM_read_only == a )
+          read_only = true;
+        else
+          throw PlDomainError("mode_option", opt[1]);
       } else
       { lookup_optdef_and_apply(&options, optdefs, name, opt);
       }
@@ -1296,20 +1303,18 @@ PREDICATE(rocks_open_, 3)
       throw PlTypeError("option", opt);
   }
 
-  if ( alias && once )
-  { atom_t existing;
-
-    if ( (existing=rocks_get_alias(alias)) )
+  if ( alias.not_null() && once )
+  { PlAtom existing = rocks_get_alias(alias);
+    if ( existing.not_null() )
     { dbref *eref;
-
       if ( (eref=symbol_dbref(existing)) &&
 	   (eref->flags&DB_OPEN_ONCE) )
-	return PL_unify_atom(A2, existing);
+	return A2.unify_atom(existing);
     }
   }
 
   dbref *ref = static_cast<dbref *>(PL_malloc(sizeof *ref));
-  memset(ref, 0, sizeof *ref);
+  *ref = null_dbref;
   ref->merger         = merger;
   ref->builtin_merger = builtin_merger;
   ref->type.key       = key_type;
@@ -1344,30 +1349,31 @@ PREDICATE(rocks_close, 1)
   get_rocks(A1, &ref);
   DB* db = ref->db;
 
-  ref->db = NULL;
+  ref->db = nullptr;
   ref->flags |= DB_DESTROYED;
-  if ( ref->name )
+  if ( ref->name.not_null() )
   { rocks_unalias(ref->name);
-    ref->name = NULL_ATOM;
+    ref->name.reset();
   }
 
   delete db;
-  return TRUE;
+  return true;
 }
 
 
 static WriteOptions
 write_options(PlTerm options_term)
 { WriteOptions options;
-  PlTail tail(options_term);
-  PlTerm opt;
+  PlTerm_tail tail(options_term);
+  PlTerm_var opt;
   while(tail.next(opt))
-  { atom_t name;
-    size_t arity;
+  { PlAtom name;
+    ARITY_T arity;
 
-    if ( PL_get_name_arity(opt, &name, &arity) && arity == 1 )
-     lookup_write_optdef_and_apply(&options, write_optdefs, name, opt);
-    else
+    opt.name_arity(&name, &arity);
+    if ( arity == 1 )
+    { lookup_write_optdef_and_apply(&options, write_optdefs, name, opt);
+    } else
       throw PlTypeError("option", opt);
   }
   return options;
@@ -1387,8 +1393,8 @@ PREDICATE(rocks_put, 4)
     get_slice(A3, value, ref->type.value);
     ok(ref->db->Put(write_options(A4), key, value));
   } else
-  { PlTail list(A3);
-    PlTerm tmp;
+  { PlTerm_tail list(A3);
+    PlTerm_var tmp;
     std::string value;
     PlSlice s;
 
@@ -1404,7 +1410,7 @@ PREDICATE(rocks_put, 4)
     ok(ref->db->Put(write_options(A4), key, value));
   }
 
-  return TRUE;
+  return true;
 }
 
 PREDICATE(rocks_merge, 4)
@@ -1420,21 +1426,21 @@ PREDICATE(rocks_merge, 4)
 
   ok(ref->db->Merge(write_options(A4), key, value));
 
-  return TRUE;
+  return true;
 }
 
 static ReadOptions
 read_options(PlTerm options_term)
 { ReadOptions options;
-  PlTail tail(options_term);
-  PlTerm opt;
+  PlTerm_tail tail(options_term);
+  PlTerm_var opt;
   while(tail.next(opt))
-  { atom_t name;
-    size_t arity;
-
-    if ( PL_get_name_arity(opt, &name, &arity) && arity == 1 )
-     lookup_read_optdef_and_apply(&options, read_optdefs, name, opt);
-    else
+  { PlAtom name;
+    ARITY_T arity;
+    opt.name_arity(&name, &arity);
+    if ( arity == 1 )
+    { lookup_read_optdef_and_apply(&options, read_optdefs, name, opt);
+    } else
       throw PlTypeError("option", opt);
   }
   return options;
@@ -1488,7 +1494,7 @@ save_enum_state(enum_state *state)
     { copy->prefix.string = static_cast<char *>(malloc(copy->prefix.length+1));
       memcpy(copy->prefix.string, state->prefix.string, copy->prefix.length+1);
     }
-    copy->saved = TRUE;
+    copy->saved = true;
     return copy;
   }
 
@@ -1506,7 +1512,7 @@ free_enum_state(enum_state *state)
   }
 }
 
-static int
+static bool
 unify_enum_key(PlTerm t, const enum_state *state)
 { if ( state->type == ENUM_PREFIX )
   { Slice k(state->it->key());
@@ -1518,21 +1524,21 @@ unify_enum_key(PlTerm t, const enum_state *state)
 
       return unify(t, k, state->ref->type.key);
     } else
-      return FALSE;
+      return false;
   } else
   { return unify(t, state->it->key(), state->ref->type.key);
   }
 }
 
 
-static int
+static bool
 enum_key_prefix(const enum_state *state)
 { if ( state->type == ENUM_PREFIX )
   { Slice k(state->it->key());
     return ( k.size_ >= state->prefix.length &&
 	     memcmp(k.data_, state->prefix.string, state->prefix.length) == 0 );
   } else
-    return TRUE;
+    return true;
 }
 
 
@@ -1551,10 +1557,9 @@ rocks_enum(PlTermv PL_av, int ac, enum_type type, control_t handle, ReadOptions 
 	if ( !(state->ref->type.key == BLOB_ATOM ||
 	       state->ref->type.key == BLOB_STRING ||
 	       state->ref->type.key == BLOB_BINARY) )
-	  return PL_permission_error("enum", "rocksdb", A1);
+	  throw PlPermissionError("enum", "rocksdb", A1);
 
-	if ( !PL_get_nchars(A4, &len, &prefix, REP_UTF8|CVT_IN|CVT_EXCEPTION) )
-	  return FALSE;
+	A4.nchars(&len, &prefix, REP_UTF8|CVT_IN|CVT_EXCEPTION);
 
 	if ( type == ENUM_PREFIX )
 	{ state->prefix.length = len;
@@ -1567,7 +1572,7 @@ rocks_enum(PlTermv PL_av, int ac, enum_type type, control_t handle, ReadOptions 
 	state->it->SeekToFirst();
       }
       state->type = type;
-      state->saved = FALSE;
+      state->saved = false;
       goto next;
     case PL_REDO:
       state = static_cast<enum_state *>(PL_foreign_context_address(handle));
@@ -1582,21 +1587,21 @@ rocks_enum(PlTermv PL_av, int ac, enum_type type, control_t handle, ReadOptions 
 	  { PL_retry_address(save_enum_state(state));
 	  } else
 	  { free_enum_state(state);
-	    return TRUE;
+	    return true;
 	  }
 	}
 	fr.rewind();
       }
       free_enum_state(state);
-      return FALSE;
+      return false;
     }
     case PL_PRUNED:
       state = static_cast<enum_state *>(PL_foreign_context_address(handle));
       free_enum_state(state);
-      return TRUE;
+      return true;
     default:
       assert(0);
-      return FALSE;
+      return false;
   }
   PL_fail;
 }
@@ -1618,26 +1623,23 @@ static PlAtom ATOM_put("put");
 
 static void
 batch_operation(const dbref *ref, WriteBatch &batch, PlTerm e)
-{ atom_t name;
-  size_t arity;
+{ PlAtom name;
+  ARITY_T arity;
 
-  if ( PL_get_name_arity(e, &name, &arity) )
-  { if ( ATOM_delete == name && arity == 1 )
-    { PlSlice key;
+  e.name_arity(&name, &arity);
+  if ( ATOM_delete == name && arity == 1 )
+  { PlSlice key;
 
-      get_slice(e[1], key, ref->type.key);
-      batch.Delete(key);
-    } else if ( ATOM_put == name && arity == 2 )
-    { PlSlice key, value;
+    get_slice(e[1], key, ref->type.key);
+    batch.Delete(key);
+  } else if ( ATOM_put == name && arity == 2 )
+  { PlSlice key, value;
 
-      get_slice(e[1], key,   ref->type.key);
-      get_slice(e[2], value, ref->type.value);
-      batch.Put(key, value);
-    } else
-    { throw PlDomainError("rocks_batch_operation", e);
-    }
+    get_slice(e[1], key,   ref->type.key);
+    get_slice(e[2], value, ref->type.value);
+    batch.Put(key, value);
   } else
-  { throw PlTypeError("compound", e);
+  { throw PlDomainError("rocks_batch_operation", e);
   }
 }
 
@@ -1647,8 +1649,8 @@ PREDICATE(rocks_batch, 3)
 
   get_rocks(A1, &ref);
   WriteBatch batch;
-  PlTail tail(A2);
-  PlTerm e;
+  PlTerm_tail tail(A2);
+  PlTerm_var e;
 
   while(tail.next(e))
   { batch_operation(ref, batch, e);
@@ -1662,19 +1664,15 @@ static PlAtom ATOM_estimate_num_keys("estimate_num_keys");
 
 PREDICATE(rocks_property, 3)
 { dbref *ref;
-  atom_t prop;
 
   get_rocks(A1, &ref);
 
-  if ( PL_get_atom(A2, &prop) )
-  { if ( ATOM_estimate_num_keys == prop )
-    { uint64_t value;
+  PlAtom prop = A2.atom();
+  if ( ATOM_estimate_num_keys == prop )
+  { uint64_t value;
 
-      return ( ref->db->GetIntProperty("rocksdb.estimate-num-keys", &value) &&
-	       PL_unify_int64(A3, value) );
-    } else
-      throw PlDomainError("rocks_property", A2);
-  }
-
-  throw PlTypeError("atom", A2);
+    return ( ref->db->GetIntProperty("rocksdb.estimate-num-keys", &value) &&
+      A3.unify_integer(value) );
+  } else
+     throw PlDomainError("rocks_property", A2);
 }

--- a/pack.pl
+++ b/pack.pl
@@ -1,6 +1,6 @@
 name(rocksdb).
 title('SWI-Prolog interface to RocksDB').
-version('0.10.0').
+version('0.11.0').
 keywords([database, embedded, nosql]).
 author('Jan Wielemaker', 'J.Wielemaker@vu.nl').
 packager( 'Jan Wielemaker', 'J.Wielemaker@cwi.nl' ).


### PR DESCRIPTION
- use new API methods where possible
- use C++ `true`, `false`, `nullptr` instead of TRUE, FALSE, NULL
- change some references to pointers
- fix some compiler warnings
- bump rocksdb version