### PR TITLE
Use more C++ features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
 #COFLAGS=-gdwarf-2 -g3
-# The following flags are the same as rocksdb uses, except that rocksdb also has -Werror
-# and doesn't have the conversion flags in ADDED_CPPFLAGS
-# TODO: Add -Werror
-# TODO: Options that work with clang
-ADDED_CPPFLAGS=-Wconversion -Warith-conversion -Wsign-conversion -Wfloat-conversion -Wno-unused-parameter
-CPPFLAGS=-Wall -Wextra -Wsign-compare -Wshadow -Wunused-parameter -Woverloaded-virtual -Wnon-virtual-dtor -Wno-missing-field-initializers -Wno-invalid-offsetof $(ADDED_CPPFLAGS) -std=c++17 -O2 $(CFLAGS) $(COFLAGS) $(LDSOFLAGS) -Irocksdb/include
+
+# For development, specify the following:
+# ADDED_CPP_FLAGS= -Wsign-compare -Wshadow -Wunused-parameter -Woverloaded-virtual -Wnon-virtual-dtor -Wno-invalid-offsetof -Wconversion -Warith-conversion -Wsign-conversion -Wfloat-conversion -Wno-unused-parameter -Wno-missing-field-initializers
+
+CPPFLAGS=-Wall $(ADDED_CPPFLAGS) -std=c++17 -O2 $(CFLAGS) $(COFLAGS) $(LDSOFLAGS) -Irocksdb/include
 LIBROCKSDB=rocksdb/librocksdb.a
 ROCKSENV=ROCKSDB_DISABLE_JEMALLOC=1 ROCKSDB_DISABLE_TCMALLOC=1
 # DEBUG_LEVEL=0 implies -O2 without assertions and debug code

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Should do the trick. Note that this clones RocksDB and builds it the way
 we need the library. This requires   significant  disk space (1.4Gb) and
 takes long (several minutes on a modern machine).
 
-This code depends on version 2 of the `SWI-cpp.h` file that is part of
+This code depends on version 2 of the `SWI-cpp2.h` file that is part of
 SWI-Prolog version 9.1.0 and later.
 
 #### Why are you not using the pre-built librocksdb?

--- a/cpp/rocksdb4pl.cpp
+++ b/cpp/rocksdb4pl.cpp
@@ -255,7 +255,7 @@ unify_rocks(PlTerm t, dbref *ref)
   { if ( ref->symbol.is_null() )
     { PlTerm_var tmp;
       PlCheckFail(tmp.unify_blob(&ref, sizeof ref, &rocks_blob));
-      ref->symbol = t.as_atom();
+      ref->symbol = tmp.as_atom();
       rocks_alias(ref->name, ref->symbol);
     }
     return t.unify_atom(ref->name);

--- a/cpp/rocksdb4pl.cpp
+++ b/cpp/rocksdb4pl.cpp
@@ -251,7 +251,7 @@ GC a rocks dbref blob from the atom garbage collector.
 [[nodiscard]]
 static dbref *
 symbol_dbref(PlAtom symbol)
-{ return cast_blob<dbref>(symbol);
+{ return PlBlobV<dbref>::cast(symbol);
 }
 
 

--- a/cpp/rocksdb4pl.cpp
+++ b/cpp/rocksdb4pl.cpp
@@ -1446,11 +1446,11 @@ enum_key_prefix(const enum_state& state)
 [[nodiscard]]
 static foreign_t
 rocks_enum(PlTermv PL_av, int ac, enum_type type, PlControl handle, rocksdb::ReadOptions options)
-{ PlForeignContextPtr<enum_state> state(handle);
+{ auto state = handle.context_unique_ptr<enum_state>();
 
   switch ( handle.foreign_control() )
   { case PL_FIRST_CALL:
-      state.set(new enum_state(get_rocks(A1)));
+      state.reset(new enum_state(get_rocks(A1)));
       if ( ac >= 4 )
       { if ( !(state->ref->type.key == BLOB_ATOM ||
 	       state->ref->type.key == BLOB_STRING ||
@@ -1478,7 +1478,7 @@ rocks_enum(PlTermv PL_av, int ac, enum_type type, PlControl handle, rocksdb::Rea
 			 state->ref->builtin_merger, state->ref->type.value) )
 	{ state->it->Next();
 	  if ( state->it->Valid() && enum_key_prefix(*state) )
-	  { PL_retry_address(state.keep());
+	  { PL_retry_address(state.release());
 	  } else
 	  { return true;
 	  }

--- a/cpp/rocksdb4pl.cpp
+++ b/cpp/rocksdb4pl.cpp
@@ -93,7 +93,7 @@ A Prolog blob consists of five parts:
       object, these could be read, write, seek, etc.).
 \end{itemize}
 
-For the \ctype{PL_blot_t structure, this API provides a set of
+For the \ctype{PL_blob_t} structure, this API provides a set of
 template functions that allow easily setting up the callbacks, and
 allow defining the corresonding methods int he blob "contents" class.
 
@@ -198,7 +198,7 @@ Explanation of the \ctype{my_blob} structure:
 
 \item The \exam{magic}, \exam{flags}, and \exam{name} flags are required.
 
-\item The \examl{release} and \examl{acquire} fields are required. The
+\item The \exam{release} and \exam{acquire} fields are required. The
       defaults given will normally suffice (see more on this in the
       definition of \exam{my_blob_contents}).
 
@@ -213,7 +213,7 @@ Explanation of the \ctype{my_blob} structure:
       \ctype{my_blob_contents}.
 
 \item The \exam{compare} and/or \exam{write} fields may optionally be
-      defined, analagously to the \exam{acquire} and \examl{release}
+      defined, analagously to the \exam{acquire} and \exam{release}
       fields. If given, you must also add a corresponding
       \exam{compare} and/or \exam{write} method(s) to
       \ctype{my_blob_contents}.
@@ -224,7 +224,7 @@ Explanation of the \ctype{my_blob_contents} structure:
 
 \begin{itemize}
 
-\item \exam{PlBlob<my_blob> provides default methods plus a few
+\item \ctype{PlBlob<my_blob>} provides default methods plus a few
       utility methods:
       \begin{itemize}
       \item Copy and move constructors are disabled, as is the
@@ -296,31 +296,6 @@ Explanation of close_my_blob/1:
       \exam{cast_blob_check<my_blob_contents>(A1.as_atom())}.
 
 \end{itemize}
-
-\subsubsection{A digression on the semantics of atoms and equality}
-\label{sec:cppw-blobs-equality}
-
-Prolog atoms differ from strings in that atom equality can be
-determined simply by comparing the atom indexes without comparing the
-string values. If the \const[PL_BLOB_UNIQUE} flag is set, then every
-time a blob is created, it is looked up in the atom table to see if
-there is another blob with the same bit pattern. If the flag is not
-set, each time a blob is created, it gets a new entry in the atom
-table.
-
-Things become a bit more complicated when we want to sort blobs.  If
-the user defines the \cfuncref{compare}{} function to return 0
-("equal") based on only some of the fields in the blob, then it is
-possible for the \cfuncref{compare}{} to mark two blobs as equal even
-if they have different indexes in the atom table. To avoid this
-inconsistency, if the \cfuncref{compare}{} function determines that
-the two blobs are equivalent, it should still do a final comparison
-using the blob pointers to enforce a total ordering -
-\cfuncref{compare_using_ptrs}{} will do that. For example, the blob
-for PCRE2 regular expressions compares the patterns of the two blobs
-and if they are equal, compares the blob pointers. In this way, if two
-blobs have the same pattern, they will not compare as equal, so sort/2
-won't remove one of them as a duplicate.
 
  ***/
 

--- a/cpp/rocksdb4pl.cpp
+++ b/cpp/rocksdb4pl.cpp
@@ -54,7 +54,7 @@
 #define DB_DESTROYED	0x0001		/* Was destroyed by user  */
 #define DB_OPEN_ONCE	0x0002		/* open(once) option */
 
-typedef enum
+enum blob_type
 { BLOB_ATOM = 0,			/* UTF-8 string as atom */
   BLOB_STRING,				/* UTF-8 string as string */
   BLOB_BINARY,				/* Byte string as string */
@@ -63,13 +63,13 @@ typedef enum
   BLOB_FLOAT32,				/* 32-bit IEEE float */
   BLOB_FLOAT64,				/* 64-bit IEEE double */
   BLOB_TERM				/* Arbitrary term */
-} blob_type;
+};
 
-typedef enum
+enum merger_t
 { MERGE_NONE = 0,
   MERGE_LIST,
   MERGE_SET
-} merger_t;
+};
 
 struct dbref
 {
@@ -1395,12 +1395,12 @@ PREDICATE(rocks_delete, 3)
   return true;
 }
 
-typedef enum
-{ ENUM_NOT_INITIALIZED,
+enum enum_type
+{ ENUM_NOT_INITIALIZED = 0,
   ENUM_ALL,  // TODO: not used?
   ENUM_FROM, // TODO: not used?
   ENUM_PREFIX
-} enum_type;
+};
 
 struct enum_state
 {

--- a/cpp/rocksdb4pl.cpp
+++ b/cpp/rocksdb4pl.cpp
@@ -45,7 +45,391 @@
 #include <SWI-Prolog.h>
 #include <SWI-cpp2.h>
 
-#include <SWI-cpp2.cpp> // TODO: this should possibly be in a separate file
+#include <SWI-cpp2.cpp> // This could be put in a separate file
+
+// ------------------- To be added to SWI-cpp2.h for blobs -----------
+
+// TODO: these should be in a namespace
+
+/*** Documentation (This will go into pl2cpp2.doc)
+
+\subsection{Blobs}
+\label{sec:cpp2-blobs}
+
+
+Disclaimer:
+The blob API for C++ is not completely general, but is designed to
+make a specific use case easier to write. For other use cases, the
+underlying C API can still be used. The use case is:
+\begin{itemize}
+\item The blob contains the foreign object (e.g., contains a
+      pointer to a database connection).
+\item The blob is created by a predicate that makes the foreign
+      object and stores it (or a pointer to it) within the blob.
+      For example, makes a connection to a database or compiles
+      a regular expression into an internal form.
+\item Optionally, there is a predicate that deletes the foreign object.
+\item The blob will not be subclassed.
+\item The blob is defined as a subclass of \ctype{PlBlob}, which
+      provides a number of fields and methods, of which a few
+      can be overridden in the blob (notably: write(), compare(),
+      and the destructor).
+\item The blob's constructor throws an exception and cleans up
+      any resources if it cannot create the blob.
+\item The foreign object can be deleted when the blob is deleted.
+\item The blob's allocation is controlled by Prolog and its
+      destructor is envoked when the blob is garbage collected.
+end{itemize}
+
+A Prolog blob consists of five parts:
+\begin{itemize}
+\item A \ctype{PL_blob_t} structure that defines the callbacks.
+\item A "contents" structure that contains the blob.
+\item A "create" or "open" predicate that unifies one of its arguments
+      with a newly created blob that contains the foreign object.
+\item (Optionally) a "close" predicate that does the opposit of the
+      "create"/"open" predicate.
+\item Predicates that manipulate the foreign object (e.g., for a file-like
+      object, these could be read, write, seek, etc.).
+\end{itemize}
+
+For the \ctype{PL_blot_t structure, this API provides a set of
+template functions that allow easily setting up the callbacks, and
+allow defining the corresonding methods int he blob "contents" class.
+
+For the "contents" structure, which is subclassed from \ctype{PlBlob},
+the programmer defines the various fields, a constructor that
+initializes them, and a destructor.  Optionally, methods can be
+defined for one of more of blob \cfuncref{compare}{},
+\cfuncref{write}{}, \cfuncref{save}{}, \cfuncref{load}{} (the
+\cfuncref{acquire}{} and \cfuncref{release}{} callbacks should
+normally be allowed to default to what is defined in \ctype{PlBlob}.
+
+There is a mismatch between how Prolog does memory management (and
+garbage collection) and how C++ does it. In particular, Prolog assumes
+that cleanup will be done in the \cfuncref{release}{} function
+associated with the blob whereas C++ typically does cleanup in a
+destructor. The blob interface gets around this mismatch by providing
+a default \cfuncref{release}{} function that assumes that the blob was
+created using \const{PL_BLOB_NOCOPY} and manages memory using a
+\ctype{std::unique_ptr}.
+
+The C blob interface has a flag that determines how memory is managed:
+\const{PL_BLOB_NOCOPY}. If this is set, Prolog does not do a call to
+cfuncref{free} when the blob is garbage collected; instead, it assumes
+that the blob's cfuncref{release} function will free the memory.
+
+The C++ API for blobs only supports blobs with
+\const{PL_BLOB_NOCOPY}.\footnote{The API can probably also support
+blobs with \const{PL_BLOB_UNIQUE}, but there seems to be little
+point in setting this flag for non-text blobs.}
+
+\subsubsection{How to define a blob using C++}
+\label{sec:cpp2-blobs-howto}
+
+TL;DR: Use PL_BLOB_NOCOPY (or an extra level of indirection) and the
+default \ctype{PlBlob} wrappers; no copy constructor, move
+constructor, or assignment operator; create blob with
+\exam{make_unique}, use \exam{unique_ptr::release}, do \exam{delete}
+in the "release" function.
+
+Here is minimal sample code for creating a blob that owns a connection
+to a database:
+
+\begin{code}
+PL_blob_t my_blob =
+{ .magic   = PL_BLOB_MAGIC,
+  .flags   = PL_BLOB_NOCOPY,
+  .name    = "my_blob",
+  .release = blob_release<my_blob>,
+  .write   = blob_write<my_blob>,
+  .acquire = blob_acquire<my_blob>,
+  .save    = blob_save<my_blob>,
+  .load    = blob_save<my_blob>
+};
+
+struct my_blob_contents : public PlBlob<my_blob>
+{ DbConnection *connection;
+
+  explicit my_blob_contents()
+    : DbConnection(nullptr)) { }
+
+  ~my_blob_contents()
+  { if ( connection )
+    { // This is similar to close_my_blob/1, except there's
+      // no check for an error because there's nothing we
+      // can do on an error because  throwing a C++ exception
+      // inside of C code will cause a runtime error.
+      (void)connection->close();
+    }
+  }
+};
+
+// %! create_my_blob(+Options: list, -MyBlob) is semidet.
+PREDICATE(create_my_blob, 2)
+{ auto ref = std::make_unique<MyBlob>(...);
+  // ... fill in the fields of *ref from options in A1  ...
+  int rc = do_open(..., &ref->connection);
+  if ( !rc )
+    throw PlGeneralError(PlCompound("my_blob_error", ref->symbol_term()));
+  PlCheckFail(A2.unify_blob(ref.get(), sizeof *ref, &my_blob));
+  (void)ref.release();
+  return true;
+
+// %! close_my_blob(+MyBlob) is det.
+// % Close the connection, silently succeeding if is already
+// % closed; throw an exception if something goes wrong.
+PREDICATE(close_my_blob, 1)
+{ auto ref = cast_blob_check<my_blob_contents>(A1.as_atom());
+  auto c = ref->connection;
+  ref->connection = nullptr;
+  if ( c )
+  { int rc = c->close();
+    delete c;
+    if ( !rc )
+      throw PlGeneralError(PlCompound("my_blob_error", ...));
+  }
+  return true;
+}
+\end{code}
+
+Explanation of the \ctype{my_blob} structure:
+\begin{itemize}
+
+\item The \exam{magic}, \exam{flags}, and \exam{name} flags are required.
+
+\item The \examl{release} and \examl{acquire} fields are required. The
+      defaults given will normally suffice (see more on this in the
+      definition of \exam{my_blob_contents}).
+
+\item If the fields \exam{save} and \exam{load} are given, they
+      provide a default implementation that throws an error on an
+      attempt to save the blob (e.g., by using
+      \qsave_program/[1,2]). If they are omitted, the defaults for
+      \exam{save} and \exam{load} are used, which save the internal
+      form of the blob, which is probably not what you want. If you
+      wish to define your own \exam{save} and \exam{load}, you must
+      also add \exam{save} and \exam{load} methods to
+      \ctype{my_blob_contents}.
+
+\item The \exam{compare} and/or \exam{write} fields may optionally be
+      defined, analagously to the \exam{acquire} and \examl{release}
+      fields. If given, you must also add a corresponding
+      \exam{compare} and/or \exam{write} method(s) to
+      \ctype{my_blob_contents}.
+
+\end{itemize}
+
+Explanation of the \ctype{my_blob_contents} structure:
+
+\begin{itemize}
+
+\item \exam{PlBlob<my_blob> provides default methods plus a few
+      utility methods:
+      \begin{itemize}
+      \item Copy and move constructors are disabled, as is the
+            assignment operator.
+      \item validate() verifies that the blob is valid, assumign that
+            the default \cfuncref{acquire}{} has been called.
+      \item acquire() is used by the default \cfuncref{acquire}{} function.
+      \item symbol_not_null() tests whether \exam{symbol} has been set
+            (this will normally be the case, unless the \cfuncref{acquire}{}
+            function hasn't been called as part of the blob creation
+            process.
+      \item symbol_term() Creates a term the contains the blob, for
+            use in error terms. It is always safe to use this; if
+            the symbol hasn't bene set, symbol_term() returns a "var" term.
+      \item compare_using_ptrs() The default method of comparison, used to
+            break ties between otherwise equal blobs.
+      \item write() A default implementation that outputs \exam{<my_blob>(ptr)}.
+      \item save() Generates an error when attempting to save the blob.
+      \item laod() generates an error when attemptint to laod the blob.
+      \end{itemize}
+
+\item The constructor must initialize fields so that the destructor
+      can determine whether to delete them or not. Typically, this is
+      done by setting pointers to \const{nullptr} or by setting a
+      flag.
+
+\item The destructor is called by \cfuncref{release}{}, assuming you've
+      set \exam{my_blob::release} to \exam{blob_release<my_blob>}.
+
+\item This blob uses the default methods for compare() and write().
+      You can change this by defining your own compare() and write()
+      methods.  If you define compare(), you must add the related line
+      to \exam{my_blob} and you should call compare_using_ptrs() if
+      your comparison of the two objects shows equality (this breaks
+      the tie for two otherwise equal by distinct objects).
+
+\end{itemize}
+
+Explanation of open_my_blob/2:
+
+\begin{itemize}
+
+\item \exam{std::make_unique<MyBlob>(...)} creates a
+      \ctype{std::unique_ptr<MyBlob>} that is deleted when it goes out
+      of scope. If an exception occurs between the creation of blob
+      (as a \ctype{std::unique_ptr<MyBlob>}) and the call to
+      \cfuncref{unify_blob}{}, the pointer will be freed (and the
+      \ctype{MyBlob} destructor will be called.
+
+\item The exception term contains the blob, using
+      \exam{ref->symbol_term()}.
+
+\item \exam{ref.release()} prevents the pointer from being
+      automatically deleted; it is now "owned" by Prolog and is
+      deleted in the \cfuncref{release}{} function (which is defined in
+      \ctype{PlBlob}).
+
+\end{itemize}
+
+Explanation of close_my_blob/1:
+
+\begin{itemize}
+
+\item This code is similar to ~my_blob_contents(), except it throws
+      an error if something goes wrong during the "close".
+
+\item Other predicates that use the blob access the
+      blob from the arguments the same way, namely
+      \exam{cast_blob_check<my_blob_contents>(A1.as_atom())}.
+
+\end{itemize}
+
+\subsubsection{A digression on the semantics of atoms and equality}
+\label{sec:cppw-blobs-equality}
+
+Prolog atoms differ from strings in that atom equality can be
+determined simply by comparing the atom indexes without comparing the
+string values. If the \const[PL_BLOB_UNIQUE} flag is set, then every
+time a blob is created, it is looked up in the atom table to see if
+there is another blob with the same bit pattern. If the flag is not
+set, each time a blob is created, it gets a new entry in the atom
+table.
+
+Things become a bit more complicated when we want to sort blobs.  If
+the user defines the \cfuncref{compare}{} function to return 0
+("equal") based on only some of the fields in the blob, then it is
+possible for the \cfuncref{compare}{} to mark two blobs as equal even
+if they have different indexes in the atom table. To avoid this
+inconsistency, if the \cfuncref{compare}{} function determines that
+the two blobs are equivalent, it should still do a final comparison
+using the blob pointers to enforce a total ordering -
+\cfuncref{compare_using_ptrs}{} will do that. For example, the blob
+for PCRE2 regular expressions compares the patterns of the two blobs
+and if they are equal, compares the blob pointers. In this way, if two
+blobs have the same pattern, they will not compare as equal, so sort/2
+won't remove one of them as a duplicate.
+
+ ***/
+
+template<typename C_t> [[nodiscard]]
+static C_t *
+cast_blob(PlAtom aref)
+{ size_t len;
+  PL_blob_t *type;
+  auto ref = static_cast<C_t *>(aref.blob_data(&len, &type));
+  if ( ref && type == ref->blob_t_)
+  { assert(len == sizeof *ref);
+    assert(ref->validate());
+    return ref;
+  }
+  return nullptr;
+}
+
+template<typename C_t> [[nodiscard]]
+static C_t*
+cast_blob_check(PlAtom aref)
+{ auto ref = cast_blob<C_t>(aref);
+  assert(ref);
+  return ref;
+}
+
+template<typename C_t>
+void blob_acquire(atom_t a)
+{ PlAtom a_(a);
+  auto data = cast_blob_check<C_t>(a_);
+  data->acquire(a_);
+}
+
+template<typename C_t> [[nodiscard]]
+int blob_release(atom_t a)
+{ auto data = cast_blob_check<C_t>(PlAtom(a));
+  delete data;
+  return true;
+}
+
+template<typename C_t> [[nodiscard]]
+int blob_compare(atom_t a, atom_t b)
+{ const auto data = cast_blob_check<C_t>(PlAtom(a));
+  return data->compare(PlAtom(b));
+}
+
+template<typename C_t> [[nodiscard]]
+int blob_write(IOSTREAM *s, atom_t a, int flags)
+{ const auto data = cast_blob_check<C_t>(PlAtom(a));
+  return data->write(s, flags);
+}
+
+template<typename C_t> [[nodiscard]]
+int blob_save(atom_t a, IOSTREAM *fd)
+{ const auto data = cast_blob_check<C_t>(PlAtom(a));
+  return data->save(fd);
+}
+
+template<typename C_t> [[nodiscard]]
+atom_t blob_load(IOSTREAM *fd)
+{ return C_t::load(fd).C_;
+}
+
+template<const PL_blob_t& blob_t>
+class PlBlob
+{
+public:
+  explicit PlBlob()
+    : blob_t_(&blob_t),
+      symbol_(PlAtom(PlAtom::null)) // filled in by acquire()
+  { }
+  explicit PlBlob(const PlBlob&) = delete;
+  explicit PlBlob(PlBlob&&) = delete;
+  PlBlob& operator =(const PlBlob&) = delete;
+  ~PlBlob() = default;
+
+  bool validate() const { return blob_t_ == &blob_t; }
+
+  void acquire(PlAtom _symbol) { symbol_ = _symbol; }
+
+  bool symbol_not_null() const { return symbol_.not_null(); }
+  PlTerm symbol_term() const
+  { if ( symbol_not_null() )
+      return PlTerm_atom(symbol_);
+    return PlTerm_var();
+  }
+
+  // TODO: document that release() is handled by the destructor
+
+  // compare() is provided as a fall-back for when other comparison's don't work.
+  // It's OK to specify it; but it's the same as the default comparison
+  int compare_using_ptrs(PlAtom _b) const {
+    const auto b = cast_blob_check<PlBlob>(_b);
+    return this > b ? 1 : this < b ? -1 : 0; }
+
+  bool write(IOSTREAM *s, int flags) const { Sfprintf(s, "<%s>(%p)", blob_t.name, this); return true; }
+
+  bool save(IOSTREAM *fd) const { return PL_warning("Cannot save reference to <%s>(%p)", blob_t.name, this); }
+
+  static PlAtom load(IOSTREAM *fd)
+  { (void)PL_warning("Cannot load reference to <%s>", blob_t.name);
+    PL_fatal_error("Cannot load reference to <%s>", blob_t.name);
+    return PlAtom(PlAtom::null);
+  }
+
+  const PL_blob_t *blob_t_;
+  PlAtom symbol_;		/* associated symbol (used for error terms) */
+};
+
+// ------------------- end: To be added to SWI-cpp2.h for blobs -----------
 
 [[nodiscard]] static PlAtom rocks_get_alias(PlAtom name);
 [[nodiscard]] static PlAtom rocks_get_alias_inside_lock(PlAtom name);
@@ -92,22 +476,33 @@ static const char* merge_t_char[] =
   "set"
 };
 
-
 struct dbref_type_kv
 { blob_type key;
   blob_type value;
 };
 
 
-#define DBREF_MAGIC 0xDB00DB01
+struct dbref;
 
 
-struct dbref
+static PL_blob_t rocks_blob =
+{ .magic   = PL_BLOB_MAGIC,
+  .flags   = PL_BLOB_NOCOPY,
+  .name    = "rocksdb",
+  .release = blob_release<dbref>,
+  .compare = blob_compare<dbref>,
+  .write   = blob_write<dbref>,
+  .acquire = blob_acquire<dbref>,
+  .save    = blob_save<dbref>,
+  .load    = blob_load<dbref>
+};
+
+
+struct dbref : PlBlob<rocks_blob>
 {
   dbref()
     : db(             nullptr),
       pathname(       PlAtom(PlAtom::null)),
-      symbol(         PlAtom(PlAtom::null)), // filled in by acquire_rocks_ref_()
       name(           PlAtom(PlAtom::null)),
       builtin_merger( MERGE_NONE),
       merger(         PlRecord(PlRecord::null)),
@@ -115,9 +510,36 @@ struct dbref
                         .value = BLOB_ATOM})
   { }
 
-  dbref(const dbref&) = delete;
-  dbref(dbref&&) = delete;
-  dbref& operator =(const dbref&) = delete;
+  bool write(IOSTREAM *s, int flags) const /* override */
+  { Sfprintf(s, "<%s>(%p", blob_t_->name, this);
+    if ( pathname.not_null() )
+      Sfprintf(s, ",path=%Ws", pathname.as_wstring().c_str());
+    if ( name.not_null() )
+      Sfprintf(s, ",alias=%Ws", name.as_wstring().c_str());
+    if (builtin_merger != MERGE_NONE)
+      Sfprintf(s, ",builtin_merger=%s", merge_t_char[builtin_merger]);
+    if ( merger.not_null() )
+    { auto m(merger.term());
+      if ( m.not_null() )
+	Sfprintf(s, ",merger=%Ws", m.as_wstring().c_str());
+    }
+    if ( !db )
+      Sfprintf(s, ",CLOSED");
+    Sfprintf(s, ",key=%s,value=%s)", blob_type_char[type.key], blob_type_char[type.value]);
+    if ( flags&PL_WRT_NEWLINE )
+      Sfprintf(s, "\n");
+    return true;
+  }
+
+  int compare(PlAtom _b) const
+  { const auto b = cast_blob_check<dbref>(_b);
+    if ( this == b ) // Prolog should have already done this test, but it's cheap
+      return 0;
+    int c_pathname = PlTerm_atom(pathname).compare(PlTerm_atom(b->pathname));
+    if ( c_pathname != 0 )
+      return c_pathname;
+    return compare_using_ptrs(_b);
+  }
 
   ~dbref()
   { // See also predicate rocks_close/1
@@ -135,40 +557,12 @@ struct dbref
     }
   }
 
-  unsigned magic = DBREF_MAGIC;
   rocksdb::DB	*db;			/* DB handle */
   PlAtom         pathname;              /* DB's absolute file name (for debugging) */
-  PlAtom         symbol;		/* associated symbol (used for error terms) */
   PlAtom	 name;			/* alias name (can be PlAtom::null) */
   merger_t	 builtin_merger;	/* C++ Merger */
   PlRecord	 merger;		/* merge option */
   dbref_type_kv  type;                  /* key and value types */
-};
-
-
-static void acquire_rocks_ref_(PlAtom aref);
-static bool release_rocks_ref_(PlAtom aref);
-static bool write_rocks_ref_(IOSTREAM *s, PlAtom aref, int flags);
-static bool write_rocks_ref_(IOSTREAM *s, const dbref& ref, int flags);
-static bool save_rocks_(PlAtom aref, IOSTREAM *fd);
-static PlAtom load_rocks_(IOSTREAM *fd);
-
-static void acquire_rocks_ref(atom_t symbol);
-static int release_rocks_ref(atom_t aref);
-static int write_rocks_ref(IOSTREAM *s, atom_t aref, int flags);
-static int save_rocks(atom_t aref, IOSTREAM *fd);
-static atom_t load_rocks(IOSTREAM *fd);
-
-static PL_blob_t rocks_blob =
-{ .magic   = PL_BLOB_MAGIC,
-  .flags   = PL_BLOB_NOCOPY,
-  .name    = "rocksdb",
-  .release = release_rocks_ref,
-  .compare = nullptr,
-  .write   = write_rocks_ref,
-  .acquire = acquire_rocks_ref,
-  .save    = save_rocks,
-  .load    = load_rocks
 };
 
 
@@ -242,135 +636,16 @@ rocks_unalias(PlAtom name)
 		 *	 SYMBOL REFERENCES	*
 		 *******************************/
 
-[[nodiscard]]
-static dbref *
-cast_dbref_blob(PlAtom aref)
-{ size_t len;
-  PL_blob_t *type;
-  auto ref = static_cast<dbref *>(aref.blob_data(&len, &type));
-  if ( ref && type == &rocks_blob)
-  { assert(len == sizeof *ref && ref->magic == DBREF_MAGIC);
-    return ref;
-  }
-  return nullptr;
-}
-
-[[nodiscard]]
-static dbref *
-cast_dbref_blob_check(PlAtom aref)
-{ auto ref = cast_dbref_blob(aref);
-  assert(ref);
-  return ref;
-}
-
-static void
-acquire_rocks_ref_(PlAtom aref)
-{ auto ref = cast_dbref_blob_check(aref);
-  ref->symbol = aref;
-}
-
-static void
-acquire_rocks_ref(atom_t symbol)
-{ acquire_rocks_ref_(PlAtom(symbol));
-}
-
-
-[[nodiscard]]
-static bool
-write_rocks_ref_(IOSTREAM *s, const dbref& ref, int flags)
-{ Sfprintf(s, "<rocksdb>(%p", &ref);
-  if ( ref.pathname.not_null() )
-    Sfprintf(s, ",path=%Ws", ref.pathname.as_wstring().c_str());
-  if ( ref.name.not_null() )
-    Sfprintf(s, ",alias=%Ws", ref.name.as_wstring().c_str());
-  if (ref.builtin_merger != MERGE_NONE)
-    Sfprintf(s, ",builtin_merger=%s", merge_t_char[ref.builtin_merger]);
-  if ( ref.merger.not_null() )
-  { auto m(ref.merger.term());
-    if ( m.not_null() )
-      Sfprintf(s, ",merger=%Ws", m.as_wstring().c_str());
-  }
-  if ( !ref.db )
-    Sfprintf(s, ",CLOSED");
-  Sfprintf(s, ",key=%s,value=%s)", blob_type_char[ref.type.key], blob_type_char[ref.type.value]);
-  if ( flags&PL_WRT_NEWLINE )
-    Sfprintf(s, "\n");
-  return true;
-}
-
-[[nodiscard]]
-static bool
-write_rocks_ref_(IOSTREAM *s, PlAtom aref, int flags)
-{ const auto ref = cast_dbref_blob_check(aref);
-  return write_rocks_ref_(s, *ref, flags);
-}
-
-[[nodiscard]]
-static int // TODO: bool
-write_rocks_ref(IOSTREAM *s, atom_t aref, int flags)
-{ return write_rocks_ref_(s, PlAtom(aref), flags);
-}
-
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 GC a rocks dbref blob from the atom garbage collector.
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-[[nodiscard]]
-static bool
-release_rocks_ref_(PlAtom aref)
-{ auto ref = cast_dbref_blob_check(aref);
-
-  delete ref;
-
-  return true;
-}
-
-[[nodiscard]]
-static int // TODO: bool
-release_rocks_ref(atom_t aref)
-{ return release_rocks_ref_(PlAtom(aref));
-}
-
-[[nodiscard]]
-static bool
-save_rocks_(PlAtom aref, IOSTREAM *fd)
-{ const auto ref = cast_dbref_blob_check(aref);
-  (void)fd;
-
-  return PL_warning("Cannot save reference to <rocksdb>(%p)", ref);
-}
-
-[[nodiscard]]
-static int // TODO: bool
-save_rocks(atom_t aref, IOSTREAM *fd)
-{ return save_rocks_(PlAtom(aref), fd);
-}
-
-[[nodiscard]]
-static PlAtom
-load_rocks_(IOSTREAM *fd)
-{ (void)fd;
-
-  (void)PL_warning("Cannot load reference to <rocksdb>");
-  PL_fatal_error("Cannot load reference to <rocksdb>");
-  return PlAtom(PlAtom::null);
-}
-
-static atom_t
-load_rocks(IOSTREAM *fd)
-{ const auto a = load_rocks_(fd);
-  if ( a.not_null() )
-    return a.C_;
-  PL_fatal_error("Cannot load reference to <rocksdb>");
-  return 0;
-}
-
 
 [[nodiscard]]
 static dbref *
 symbol_dbref(PlAtom symbol)
-{ return cast_dbref_blob(symbol);
+{ return cast_blob<dbref>(symbol);
 }
 
 
@@ -380,7 +655,7 @@ get_rocks(PlTerm t, bool throw_if_closed=true)
 { PlAtom a(t.as_atom()); // Throws type error if not an atom
 
   auto ref = symbol_dbref(a);
-  if ( ! ref )
+  if ( !ref )
   { a = rocks_get_alias(a);
     if ( a.not_null() )
       ref = symbol_dbref(a);
@@ -399,10 +674,10 @@ get_rocks(PlTerm t, bool throw_if_closed=true)
 
 static PlException
 RocksError(const rocksdb::Status& status, const dbref *ref)
-{ if ( ref && ref->symbol.not_null() )
+{ if ( ref )
     return PlGeneralError(PlCompound("rocks_error",
 				     PlTermv(PlTerm_atom(status.ToString()),
-					     PlTerm_atom(ref->symbol))));
+					     ref->symbol_term())));
   return PlGeneralError(PlCompound("rocks_error",
 				   PlTermv(PlTerm_atom(status.ToString()))));
 }
@@ -782,8 +1057,7 @@ public:
   }
 };
 
-template<typename Number_t>
-[[nodiscard]]
+template<typename Number_t> [[nodiscard]]
 static int
 cmp_number(const void *v1, const void *v2)
 { const auto i1 = static_cast<const Number_t *>(v1);
@@ -949,10 +1223,10 @@ lookup_read_optdef_and_apply(rocksdb::ReadOptions *options,
   { const PlAtom name;
     const ReadOptdefAction action;
 
-    ReadOptdef(const char *name_, ReadOptdefAction action_)
-      : name(name_), action(action_) { }
-    ReadOptdef(PlAtom atom_, ReadOptdefAction action_)
-      : name(atom_), action(action_) { }
+    ReadOptdef(const char *_name, ReadOptdefAction _action)
+      : name(_name), action(_action) { }
+    ReadOptdef(PlAtom _atom, ReadOptdefAction _action)
+      : name(_atom), action(_action) { }
   };
 
   // TODO: #define RD_ODEF [options](PlTerm arg)
@@ -1024,10 +1298,10 @@ lookup_write_optdef_and_apply(rocksdb::WriteOptions *options,
   { const PlAtom name;
     const WriteOptdefAction action;
 
-    WriteOptdef(const char *name_, WriteOptdefAction action_)
-      : name(name_), action(action_) { }
-    WriteOptdef(PlAtom atom_, WriteOptdefAction action_)
-      : name(atom_), action(action_) { }
+    WriteOptdef(const char *_name, WriteOptdefAction _action)
+      : name(_name), action(_action) { }
+    WriteOptdef(PlAtom _atom, WriteOptdefAction _action)
+      : name(_atom), action(_action) { }
   };
 
   // TODO: #define WR_ODEF [options](PlTerm arg)
@@ -1095,10 +1369,10 @@ lookup_open_optdef_and_apply(rocksdb::Options *options,
   { const PlAtom name;
     const OpenOptdefAction action;
 
-    OpenOptdef(const char *name_, OpenOptdefAction action_)
-      : name(name_), action(action_) { }
-    OpenOptdef(PlAtom atom_, OpenOptdefAction action_)
-      : name(atom_), action(action_) { }
+    OpenOptdef(const char *_name, OpenOptdefAction _action)
+      : name(_name), action(_action) { }
+    OpenOptdef(PlAtom _atom, OpenOptdefAction _action)
+      : name(_atom), action(_action) { }
   };
 
   // TODO: #define ODEF [options](PlTerm arg)
@@ -1353,6 +1627,7 @@ PREDICATE(rocks_open_, 3)
   // Allocating the blob uses unique_ptr<dbref> so that it'll be
   // deleted if an error happens - this is disabled by ref.release()
   // before returning success.
+
   auto ref = std::make_unique<dbref>();
   ref->merger         = merger;
   ref->builtin_merger = builtin_merger;
@@ -1397,7 +1672,7 @@ PREDICATE(rocks_close, 1)
 
   if ( ref->name.not_null() )
   { rocks_unalias(ref->name);
-    // ref->name is needed by write_rocks_ref_(), so don't: ref->name.unregister_ref()
+    // ref->name is needed by write() callabck, so don't do this: ref->name.unregister_ref()
   }
 
   { auto db = ref->db;

--- a/cpp/rocksdb4pl.cpp
+++ b/cpp/rocksdb4pl.cpp
@@ -101,17 +101,7 @@ struct dbref_type_kv
 
 struct dbref;
 
-static PL_blob_t rocks_blob =
-{ .magic   = PL_BLOB_MAGIC,
-  .flags   = PL_BLOB_NOCOPY,
-  .name    = "rocksdb",
-  .release = blob_release<dbref>,
-  .compare = blob_compare<dbref>,
-  .write   = blob_write<dbref>,
-  .acquire = blob_acquire<dbref>,
-  .save    = blob_save<dbref>,
-  .load    = blob_load<dbref>
-};
+static PL_blob_t rocks_blob = PL_BLOB_DEFINITION(dbref, "rocksdb");
 
 
 struct dbref : PlBlob<rocks_blob>

--- a/pack.pl
+++ b/pack.pl
@@ -1,7 +1,7 @@
 name(rocksdb).
 title('SWI-Prolog interface to RocksDB').
-version('0.13.0').
-keywords([database, embedded, nosql]).
+version('0.13.1').
+keywords([database, embedded, nosql, 'RocksDB']).
 author('Jan Wielemaker', 'jan@swi-prolog.org').
 packager( 'Jan Wielemaker', 'jan@swi-prolog.org' ).
 maintainer( 'Jan Wielemaker', 'jan@swi-prolog.org' ).

--- a/prolog/rocksdb.pl
+++ b/prolog/rocksdb.pl
@@ -217,9 +217,9 @@ See rocks_open/3 for details.
 %	rocksdb library, the error term is of the form
 %	rocks_error(Message) or rocks_error(Message,Blob).
 %
-%	Most of the `DBOptions` in
-%	`rocksdb/include/rocksdb/options.h` are supported, in addition
-%	to the following options:
+%	Most of the `DBOptions` in `rocksdb/include/rocksdb/options.h`
+%	are supported.  `create_if_exists` defaults to `true`.
+%	Additional options are:
 %
 %	  - alias(+Name)
 %	  Give the database a name instead of using an anonymous

--- a/prolog/rocksdb.pl
+++ b/prolog/rocksdb.pl
@@ -66,7 +66,6 @@
 
 :- predicate_options(rocks_open/3, 3,
 		     [ alias(atom),
-		       open(oneof([once])),
 		       mode(oneof([read_only,read_write])),
 		       key(oneof([atom,string,binary,int32,int64,
 				  float,double,term])),
@@ -212,7 +211,12 @@ See rocks_open/3 for details.
 %!	rocks_open(+Directory, -RocksDB, +Options) is det.
 %
 %	Open a RocksDB database in Directory and unify RocksDB with a
-%	handle to the opened database.  Most of the `DBOptions` in
+%	handle to the opened database. In general, this predicate
+%	throws an exception on failure; if an error occurs in the
+%	rocksdb library, the error term is of the form
+%	rocks_error(Message,_).
+%
+%	Most of the `DBOptions` in
 %	`rocksdb/include/rocksdb/options.h` are supported, in addition
 %	to the following options:
 %
@@ -221,9 +225,6 @@ See rocks_open/3 for details.
 %	  handle.  A named database is not subject to GC and must
 %	  be closed explicitly. When the database is opened,
 %         RocksDB unifies with Name.
-%	  - open(+How)
-%	  If How is `once` and an alias is given, a second open simply
-%	  returns a handle to the already open database.
 %	  - key(+Type)
 %	  - value(+Type)
 %	  Define the type for the key and value. This must be
@@ -270,9 +271,12 @@ See rocks_open/3 for details.
 %	  Define RocksDB value merging.  See rocks_merge/3.
 %	  - mode(+Mode)
 %	  One of `read_write` (default) or `read_only`.  The latter
-%	  uses OpenForReadOnly() to open the database.
+%	  uses OpenForReadOnly() to open the database. It is allowed
+%	  to have multiple `read_only` opens, but only one
+%	  `read_write` (which also precludes having any `read_only`);
+%	  however, it is recommended to only open a databse once.
 %	  - optimize_for_small_db(true) - Use this if your DB is very
-%           small (like under 1GB) and you don't want tog
+%           small (like under 1GB) and you don't want to
 %           spend lots of memory for memtables.
 %         - increase_parallelism(true) - see DBOptions::IncreaseParallelism()
 % @see https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide

--- a/prolog/rocksdb.pl
+++ b/prolog/rocksdb.pl
@@ -288,7 +288,8 @@ See rocks_open/3 for details.
 
 rocks_open(Dir, DB, Options0) :-
 	meta_options(is_meta, Options0, Options),
-	rocks_open_(Dir, DB, Options).
+        absolute_file_name(Dir, DirAbs),
+	rocks_open_(DirAbs, DB, Options).
 
 is_meta(merge).
 

--- a/prolog/rocksdb.pl
+++ b/prolog/rocksdb.pl
@@ -36,6 +36,7 @@
 :- module(rocksdb,
 	  [ rocks_open/3,		% +Directory, -RocksDB, +Options
 	    rocks_close/1,		% +RocksDB
+	    rocks_alias_lookup/2,	% +Name, -RocksDB
 
 	    rocks_put/3,		% +RocksDB, +Key, +Value
 	    rocks_put/4,		% +RocksDB, +Key, +Value, +Options
@@ -222,13 +223,16 @@ See rocks_open/3 for details.
 %
 %	  - alias(+Name)
 %	  Give the database a name instead of using an anonymous
-%	  handle.  A named database is not subject to GC and must
-%	  be closed explicitly. When the database is opened,
-%         RocksDB unifies with Name.
+%	  handle.  A named database is not subject to GC and must be
+%	  closed explicitly. When the database is opened, RocksDB
+%	  unifies with Name (the underlying handle can obtained using
+%	  rocks_alias_lookup2).
+
 %	  - key(+Type)
 %	  - value(+Type)
-%	  Define the type for the key and value. This must be
-%	  consistent over multiple invocations.  Defined types are:
+%	  Define the type for the key and value. These must be
+%	  consistent over multiple invocations. Default is `atom`.
+%	  Defined types are:
 %	    - atom
 %	      Accepts an atom or string.  Unifies the result with an
 %	      atom.  Data is stored as a UTF-8 string in RocksDB.
@@ -317,6 +321,23 @@ is_meta(merge).
 %	succeeds; if it's an alias name that's already been closed, an
 %	existence error is raised (this behavior may change in
 %	future).
+
+
+%!	rocks_alias_lookup(+Name, -RocksDB) is semidet.
+%
+%	Look up an alias Name (as specified in rocks_open/3 `alias`
+%	option and unify RocksDb with the underlying handle; fails if
+%	there is no open file with the alias Name.
+%
+%	This predicate has two uses:
+%	- The other predicates have slightly faster performance when the
+%	  RocksDB handle is used instead of the Name.
+%	- Some extra debugging information is available when the blob is printed.
+%
+%	Note that `rocks_open(...,RocksDB,[alias(Name)])` unifies
+%	RocksDB with Name; if `alias(Name)` is not specified, RocksDB
+%	is unified with the underlying handle.
+
 
 %!	rocks_put(+RocksDB, +Key, +Value) is det.
 %!      rocks_put(+RocksDB, +Key, +Value, Options) is det.

--- a/prolog/rocksdb.pl
+++ b/prolog/rocksdb.pl
@@ -219,7 +219,8 @@ See rocks_open/3 for details.
 %	  - alias(+Name)
 %	  Give the database a name instead of using an anonymous
 %	  handle.  A named database is not subject to GC and must
-%	  be closed explicitly.
+%	  be closed explicitly. When the database is opened,
+%         RocksDB unifies with Name.
 %	  - open(+How)
 %	  If How is `once` and an alias is given, a second open simply
 %	  returns a handle to the already open database.
@@ -419,7 +420,7 @@ rocks_enum_from(RocksDB, Key, Value, Prefix) :-
 %
 %	True for all keys that start   with Prefix. Instead of returning
 %	the full key this predicate returns the _suffix_ of the matching
-%	key. This predicate  succeeds  deterministically   no  next  key
+%	key. This predicate  succeeds  deterministically if no next  key
 %	exists or the next key does not match Prefix.
 %
 %       Options are the same as for rocks_get/4.

--- a/prolog/rocksdb.pl
+++ b/prolog/rocksdb.pl
@@ -281,9 +281,12 @@ See rocks_open/3 for details.
 
 %
 % @bug You must call rocks_close(Directory) to ensure clean shutdown
-%      Failure to call rdb_close/1 usually doesn't result in data
-%      loss because rocksdb can recover, depending on the setting
-%      of the `sync` option.
+%	Failure to call rdb_close/1 usually doesn't result in data
+%	loss because rocksdb can recover, depending on the setting of
+%	the `sync` option. However, it is recommended that you do a
+%	clean shutdown if possible, such as using at_halt/1 or
+%	setup_call_cleanup/3 is used to ensure clean shutdown.
+
 % @see https://github.com/facebook/rocksdb/wiki/Known-Issues
 
 rocks_open(Dir, DB, Options0) :-
@@ -296,8 +299,20 @@ is_meta(merge).
 
 %!	rocks_close(+RocksDB) is det.
 %
-%	Destroy the RocksDB handle.  Note   that  anonymous  handles are
-%	subject to (atom) garbage collection.
+%	Destroy the RocksDB handle.  Note that anonymous handles are
+%	subject to (atom) garbage collection, which will call
+%	rocks_close/1 as part of the garbage collection; however,
+%	there is no guarantee that an anonymous handle will be garbage
+%	collected, so it is suggested that at_halt/1 or
+%	setup_call_cleanup/3 is used to ensure that rocks_close/1 is
+%	called.
+%
+%	rocks_close/1 throws an existence error if RocksDB isn't a
+%	valid handle or alias from rocks_open/3.  If RocksDB is an
+%	anonymous handle that has been closed, rocks_close/1 silently
+%	succeeds; if it's an alias name that's already been closed, an
+%	existence error is raised (this behavior may change in
+%	future).
 
 %!	rocks_put(+RocksDB, +Key, +Value) is det.
 %!      rocks_put(+RocksDB, +Key, +Value, Options) is det.

--- a/prolog/rocksdb.pl
+++ b/prolog/rocksdb.pl
@@ -214,7 +214,7 @@ See rocks_open/3 for details.
 %	handle to the opened database. In general, this predicate
 %	throws an exception on failure; if an error occurs in the
 %	rocksdb library, the error term is of the form
-%	rocks_error(Message,_).
+%	rocks_error(Message) or rocks_error(Message,Blob).
 %
 %	Most of the `DBOptions` in
 %	`rocksdb/include/rocksdb/options.h` are supported, in addition

--- a/prolog/rocksdb.pl
+++ b/prolog/rocksdb.pl
@@ -72,6 +72,7 @@
 				  float,double,term])),
 		       value(any),
 		       merge(callable),
+                       debug(boolean),
                        prepare_for_bulk_load(oneof([true])),
                        optimize_for_small_db(oneof([true])),
                        increase_parallelism(oneof([true])),
@@ -279,10 +280,8 @@ See rocks_open/3 for details.
 %	  to have multiple `read_only` opens, but only one
 %	  `read_write` (which also precludes having any `read_only`);
 %	  however, it is recommended to only open a databse once.
-%	  - optimize_for_small_db(true) - Use this if your DB is very
-%           small (like under 1GB) and you don't want to
-%           spend lots of memory for memtables.
-%         - increase_parallelism(true) - see DBOptions::IncreaseParallelism()
+%         - debug(true) Output more information when displaying
+%           the rocksdb "blob".
 % @see https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide
 % @see http://rocksdb.org/blog/2018/08/01/rocksdb-tuning-advisor.html
 % @see https://github.com/EighteenZi/rocksdb_wiki/blob/master/RocksDB-Tuning-Guide.md

--- a/test/test_rocksdb.pl
+++ b/test/test_rocksdb.pl
@@ -133,7 +133,7 @@ test(options5, [cleanup(delete_db)]) :-
 	    rocks_put(RocksDB, "one", "àmímé níshíkíhéꜜbì"),
 	    rocks_close(RocksDB)).
 
-test(open_twice, [error(rocks_error(_),_), % TODO: error(rocks_error('IO error: lock hold by current process, acquire time 1657004085 acquiring thread 136471553664960: /tmp/test_rocksdb/LOCK: No locks available'),_)
+test(open_twice, [error(rocks_error(_,_)), % TODO: error(rocks_error('IO error: lock hold by current process, acquire time 1657004085 acquiring thread 136471553664960: /tmp/test_rocksdb/LOCK: No locks available'),_)
 		  cleanup(delete_db)]) :-
 	test_db(Dir),
 	setup_call_cleanup(
@@ -385,6 +385,16 @@ test(dup, [setup(setup_db(Dir, DB, [alias('DB')])),
     test_db2(Dir2),
     rocks_close(DB),
     rocks_open(Dir2, DB2, [alias('DB')]).
+test(compare, [setup(setup_db(Dir, DB)),
+               cleanup((cleanup_db(Dir, DB),
+                        cleanup_db(Dir3, DB3)))]) :-
+    % This test assumes blobs get allocated in ascending order; we're
+    % checking that the ordering is by pathname, not by the default
+    % ordering of pointer.
+    test_db3(Dir3),
+    rocks_open(Dir3, DB3, []),
+    assertion(Dir3 @< Dir),
+    assertion(DB3 @< DB).
 
 :- end_tests(alias).
 
@@ -394,6 +404,7 @@ test(dup, [setup(setup_db(Dir, DB, [alias('DB')])),
 
 test_db('/tmp/test_rocksdb').
 test_db2('/tmp/test_rocksdb2').
+test_db3('/tmp/test_rocksd0').
 
 delete_db :-
     test_db(DB),

--- a/test/test_rocksdb.pl
+++ b/test/test_rocksdb.pl
@@ -131,6 +131,7 @@ test(options5, [cleanup(delete_db)]) :-
 	    rocks_open(Dir, RocksDB, [key(string), value(string), mode(read_write)]),
 	    rocks_put(RocksDB, "one", "àmímé níshíkíhéꜜbì"),
 	    rocks_close(RocksDB)).
+
 test(open_twice, [error(rocks_error(_),_), % TODO: error(rocks_error('IO error: lock hold by current process, acquire time 1657004085 acquiring thread 136471553664960: /tmp/test_rocksdb/LOCK: No locks available'),_)
 		  cleanup(delete_db)]) :-
 	test_db(Dir),
@@ -139,6 +140,7 @@ test(open_twice, [error(rocks_error(_),_), % TODO: error(rocks_error('IO error: 
 	    call_cleanup(rocks_open(Dir, RocksDB2, []),
 			 rocks_close(RocksDB2)),
 	    rocks_close(RocksDB1)).
+
 test(batch, [Pairs == [zus-noot],
 	     cleanup(delete_db)]) :-
 	test_db(Dir),

--- a/test/test_rocksdb.pl
+++ b/test/test_rocksdb.pl
@@ -348,7 +348,8 @@ test(enum,
 	findall(Key, rocks_enum_from(RocksDB, Key, _, aap), Keys),
 	rocks_enum_prefix(RocksDB, Rest, _, aapj),
 	assertion(Rest == "e"),
-	rocks_close(RocksDB).
+	rocks_close(RocksDB),   % test double-close
+        rocks_close(RocksDB).
 
 :- end_tests(enum).
 
@@ -362,7 +363,13 @@ test(basic, [Noot == noot,
 	rocks_put('DB', aap, noot),
 	rocks_get('DB', aap, Noot),
 	rocks_delete('DB', aap),
- 	assertion(\+ rocks_get('DB', aap, _)).
+ 	assertion(\+ rocks_get('DB', aap, _)),
+        % The following would throw an exception because the code
+        % doesn't distinguish between a db alias that's been closed
+        % and a db alias that's never been opened:
+        %   rocks_close('DB'),      % test double-close
+        %   rocks_close('DB').
+        true.
 
 :- end_tests(alias).
 

--- a/test/test_rocksdb.pl
+++ b/test/test_rocksdb.pl
@@ -106,7 +106,7 @@ test(options1, [error(type_error(bool,xxx),_),
 		cleanup(delete_db)]) :-
 	test_db(Dir),
 	rocks_open(Dir, _RocksDB, [error_if_exists(xxx)]).
-test(options2, [error(type_error(option,this_is_not_an_option(123)),_),
+test(options2, [error(type_error(option,this_is_not_an_option(123))),
 		cleanup(delete_db)]) :-
 	test_db(Dir),
 	rocks_open(Dir, _RocksDB, [this_is_not_an_option(123)]).
@@ -114,13 +114,14 @@ test(options3, [error(domain_error(mode_option,not_read_write),_),
 		cleanup(delete_db)]) :-
 	test_db(Dir),
 	rocks_open(Dir, _RocksDB, [mode(not_read_write)]).
-test(options4, [error(rocks_error('Not implemented: Not supported operation in read only mode.'),_),
+% TODO: verify error(rocks-error('...',Blob), the Blob is of type 'rocksdb'
+test(options4, [error(rocks_error('Not implemented: Not supported operation in read only mode.',_)),
 		cleanup(delete_db)]) :-
 	test_db(Dir),
 	rocks_open(Dir, RocksDB0, [key(string), value(string)]),
 	rocks_close(RocksDB0),
 	setup_call_cleanup(
-	    rocks_open(Dir, RocksDB, [mode(read_only)]),
+	    rocks_open(Dir, RocksDB, [mode(read_only), key(string), value(string)]),
 	    (   rocks_put(RocksDB, "one", "àmímé níshíkíhéꜜbì"),
 	        rocks_get(RocksDB, "one", "àmímé níshíkíhéꜜbì")
 	    ),

--- a/test/test_rocksdb.pl
+++ b/test/test_rocksdb.pl
@@ -352,19 +352,15 @@ test(enum,
 
 :- begin_tests(alias, [cleanup(delete_db)]).
 
-test(basic, [blocked(assertion_error),
-             Noot == noot,
-             setup(setup_db(Dir, _, [alias(rocks_db)])),
-             cleanup(cleanup_db(Dir, rocks_db))]) :-
-	rocks_put(rocks_db, aap, noot),
-	rocks_get(rocks_db, aap, Noot),
-	rocks_delete(rocks_db, aap),
- 	assertion(\+ rocks_get(rocks_db, aap, _)).
-
-test(basic2, [blocked(assertion_error),
-              error(permission_error(alias,rocksdb,rocks_db)),
-              setup(setup_db(Dir, _, [alias(rocks_db)]))]) :-
-    rocks_open(Dir, _, [alias(rocks_db)]).
+% rocks:basic, but with a named database
+test(basic, [Noot == noot,
+             setup(setup_db(Dir, DB, [alias('DB')])),
+             cleanup(cleanup_db(Dir, DB))]) :-
+	assertion(DB == 'DB'),
+	rocks_put('DB', aap, noot),
+	rocks_get('DB', aap, Noot),
+	rocks_delete('DB', aap),
+ 	assertion(\+ rocks_get('DB', aap, _)).
 
 :- end_tests(alias).
 

--- a/test/test_rocksdb.pl
+++ b/test/test_rocksdb.pl
@@ -372,6 +372,20 @@ test(basic, [Noot == noot,
         %   rocks_close('DB').
         true.
 
+test(dup, [error(permission_error(alias,rocksdb,'DB')),
+           setup(setup_db(Dir, DB, [alias('DB')])),
+           cleanup((cleanup_db(Dir, DB),
+                    cleanup_db(Dir2, DB2)))]) :-
+    test_db2(Dir2),
+    rocks_open(Dir2, DB2, [alias('DB')]).
+% As 1st dup test, but the rocks_close clears the alias entry:
+test(dup, [setup(setup_db(Dir, DB, [alias('DB')])),
+           cleanup((cleanup_db(Dir, DB),
+                    cleanup_db(Dir2, DB2)))]) :-
+    test_db2(Dir2),
+    rocks_close(DB),
+    rocks_open(Dir2, DB2, [alias('DB')]).
+
 :- end_tests(alias).
 
 		 /*******************************
@@ -379,6 +393,7 @@ test(basic, [Noot == noot,
 		 *******************************/
 
 test_db('/tmp/test_rocksdb').
+test_db2('/tmp/test_rocksdb2').
 
 delete_db :-
     test_db(DB),
@@ -401,5 +416,7 @@ setup_db(Dir, RocksDB, Options) :-
 % is an error in the test case and the database isn't closed, it will
 % cause spurious errors from all the subsequent tests.
 cleanup_db(Dir, RocksDB) :-
-    catch(ignore(rocks_close(RocksDB)), _, true),
-    delete_db(Dir).
+    catch((ignore(rocks_close(RocksDB)),
+           delete_db(Dir)),
+          _, true).
+

--- a/test/test_rocksdb.pl
+++ b/test/test_rocksdb.pl
@@ -331,7 +331,7 @@ test(basic, [cleanup(delete_db)]) :-
 :- begin_tests(enum, [cleanup(delete_db)]).
 
 test(enum,
-     [ Keys = ["aap", "aapje", "noot"],
+     [ Keys == ["aap", "aapje", "noot"],
        cleanup(delete_db)
      ]) :-
 	test_db(Dir),


### PR DESCRIPTION
- Use C++ style for structs, including constructors, destructors
- Use C++ new/delete instead of malloc()/free()
- Use C++ initializer list for constructors
- Use templates to avoid some copy&paste code
- Atom and functor static constants moved inside functions that use them
- Add [[nodiscard]]s
- Class PlSlice is encpasulates rocksdb::Slice instead of subclassing it
- Remove some inappropriate uses of PlCheckFail()

These changes were found by doing a code-review, which is why they aren't in separate, smaller PRs. 
This PR also fixes an incomplete cherry-pick for PlSlice.